### PR TITLE
Implement wait-on-address runtime and release packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,386 @@
+name: Package
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/package.yml'
+      - 'nuget/**'
+      - 'scripts/nuget/**'
+      - 'CMakeLists.txt'
+      - 'LICENSE'
+      - 'README.md'
+      - 'build.bat'
+      - 'cmake/**'
+      - 'docs/**'
+      - 'include/**'
+      - 'src/**'
+      - 'test/**'
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+    paths:
+      - '.github/workflows/package.yml'
+      - 'nuget/**'
+      - 'scripts/nuget/**'
+      - 'CMakeLists.txt'
+      - 'LICENSE'
+      - 'README.md'
+      - 'build.bat'
+      - 'cmake/**'
+      - 'docs/**'
+      - 'include/**'
+      - 'src/**'
+      - 'test/**'
+  workflow_dispatch:
+    inputs:
+      package_version:
+        description: Optional package version override
+        required: false
+        type: string
+      publish:
+        description: Publish the generated package to nuget.org
+        required: true
+        type: boolean
+        default: false
+      github_release:
+        description: Upload release assets to GitHub Releases
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Resolve package version
+    runs-on: windows-2022
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve package version
+        id: version
+        shell: pwsh
+        run: |
+          $version = '${{ inputs.package_version }}'
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            $version = ./scripts/nuget/Get-LdkVersion.ps1
+          }
+
+          if ($env:GITHUB_REF_TYPE -eq 'tag') {
+            if ($env:GITHUB_REF_NAME -notmatch '^v(.+)$') {
+              throw "Release tag must use v<version> format."
+            }
+
+            $tagVersion = $Matches[1]
+            if ($version -ne $tagVersion) {
+              throw "Package version '$version' does not match tag version '$tagVersion'."
+            }
+          }
+
+          "package_version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Package version: $version"
+
+  build-libs:
+    name: Build NuGet libs ${{ matrix.arch }} ${{ matrix.config }}
+    needs: version
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x64]
+        config: [Debug, Release]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build prebuilt libraries
+        shell: pwsh
+        run: >
+          ./scripts/nuget/Build-LdkNuGetLibs.ps1
+          -Architecture '${{ matrix.arch }}'
+          -Configuration '${{ matrix.config }}'
+          -WindowsSdkVersion '10.0.22621.0'
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ldk-nuget-libs-${{ matrix.arch }}-${{ matrix.config }}
+          path: artifacts/nuget-staging/lib/native/${{ matrix.arch }}/${{ matrix.config }}
+          if-no-files-found: error
+
+  pack:
+    name: Pack NuGet
+    needs: [version, build-libs]
+    runs-on: windows-2022
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set package version
+        id: version
+        shell: pwsh
+        run: |
+          "package_version=${{ needs.version.outputs.package_version }}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: NuGet/setup-nuget@v2
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-libs-x86-Debug
+          path: artifacts/nuget-staging/lib/native/x86/Debug
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-libs-x86-Release
+          path: artifacts/nuget-staging/lib/native/x86/Release
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-libs-x64-Debug
+          path: artifacts/nuget-staging/lib/native/x64/Debug
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-libs-x64-Release
+          path: artifacts/nuget-staging/lib/native/x64/Release
+
+      - name: Pack
+        shell: pwsh
+        run: ./scripts/nuget/Pack-LdkNuGet.ps1 -Version '${{ steps.version.outputs.package_version }}'
+
+      - name: Pack GitHub release assets
+        shell: pwsh
+        run: ./scripts/nuget/Pack-LdkReleaseAssets.ps1 -Version '${{ steps.version.outputs.package_version }}'
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ldk-nuget-${{ steps.version.outputs.package_version }}
+          path: artifacts/nuget/*.nupkg
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ldk-release-assets-${{ steps.version.outputs.package_version }}
+          path: artifacts/release/*
+          if-no-files-found: error
+
+  test-package-driver:
+    name: Test NuGet driver package ${{ matrix.arch }} ${{ matrix.config }}
+    needs: pack
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64]
+        config: [Debug, Release]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: NuGet/setup-nuget@v2
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-${{ needs.pack.outputs.package_version }}
+          path: artifacts/nuget
+
+      - name: Build package consumer test driver
+        shell: pwsh
+        run: >
+          ./scripts/nuget/Test-LdkNuGetPackage.ps1
+          -PackageDirectory artifacts/nuget
+          -Version '${{ needs.pack.outputs.package_version }}'
+          -Architecture '${{ matrix.arch }}'
+          -Configuration '${{ matrix.config }}'
+          -WindowsSdkVersion '10.0.22621.0'
+
+  test-package-layout:
+    name: Validate NuGet package layout ${{ matrix.arch }} ${{ matrix.config }}
+    needs: pack
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86]
+        config: [Debug, Release]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: NuGet/setup-nuget@v2
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-${{ needs.pack.outputs.package_version }}
+          path: artifacts/nuget
+
+      - name: Validate package layout
+        shell: pwsh
+        run: >
+          ./scripts/nuget/Test-LdkNuGetPackage.ps1
+          -PackageDirectory artifacts/nuget
+          -Version '${{ needs.pack.outputs.package_version }}'
+          -Architecture '${{ matrix.arch }}'
+          -Configuration '${{ matrix.config }}'
+          -SkipDriverBuild
+
+  test-release-prebuilt-cmake:
+    name: Test release prebuilt CMake asset ${{ matrix.arch }} ${{ matrix.config }}
+    needs: pack
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64]
+        config: [Debug, Release]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-release-assets-${{ needs.pack.outputs.package_version }}
+          path: artifacts/release
+
+      - name: Build prebuilt release CMake consumer test
+        shell: pwsh
+        run: >
+          ./scripts/nuget/Test-LdkReleaseAssets.ps1
+          -ReleaseDirectory artifacts/release
+          -Version '${{ needs.pack.outputs.package_version }}'
+          -Architecture '${{ matrix.arch }}'
+          -Configuration '${{ matrix.config }}'
+          -WindowsSdkVersion '10.0.22621.0'
+
+  test-release-prebuilt-layout:
+    name: Validate release prebuilt layout ${{ matrix.arch }} ${{ matrix.config }}
+    needs: pack
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86]
+        config: [Debug, Release]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-release-assets-${{ needs.pack.outputs.package_version }}
+          path: artifacts/release
+
+      - name: Validate prebuilt release layout
+        shell: pwsh
+        run: >
+          ./scripts/nuget/Test-LdkReleaseAssets.ps1
+          -ReleaseDirectory artifacts/release
+          -Version '${{ needs.pack.outputs.package_version }}'
+          -Architecture '${{ matrix.arch }}'
+          -Configuration '${{ matrix.config }}'
+          -SkipDriverBuild
+
+  publish:
+    name: Publish NuGet
+    needs: [pack, test-package-driver, test-package-layout]
+    if: ${{ (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    runs-on: windows-2022
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-${{ needs.pack.outputs.package_version }}
+          path: artifacts/nuget
+
+      - name: Validate NuGet trusted publishing user
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace('${{ vars.NUGET_TRUSTED_PUBLISHING_USER }}')) {
+            throw 'Repository variable NUGET_TRUSTED_PUBLISHING_USER is required for NuGet Trusted Publishing.'
+          }
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ vars.NUGET_TRUSTED_PUBLISHING_USER }}
+
+      - name: Publish to nuget.org
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: ./scripts/nuget/Push-LdkNuGet.ps1 -SkipDuplicate
+
+  github-release:
+    name: Upload GitHub Release Assets
+    needs: [pack, test-package-driver, test-package-layout, test-release-prebuilt-cmake, test-release-prebuilt-layout]
+    if: ${{ (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.github_release) }}
+    runs-on: windows-2022
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-release-assets-${{ needs.pack.outputs.package_version }}
+          path: artifacts/release
+
+      - name: Create or update GitHub release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          Set-Location '${{ github.workspace }}'
+          $version = '${{ needs.pack.outputs.package_version }}'
+          $tagName = "v$version"
+          if ('${{ github.ref_type }}' -eq 'tag') {
+            $tagName = '${{ github.ref_name }}'
+          }
+          $repo = '${{ github.repository }}'
+
+          $assets = @(Get-ChildItem -Path artifacts\release -File | Sort-Object FullName | ForEach-Object { $_.FullName })
+          if ($assets.Count -eq 0) {
+            throw 'No GitHub Release assets were found.'
+          }
+
+          & gh release view $tagName --repo $repo *> $null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Uploading assets to existing GitHub Release $tagName"
+            & gh release upload $tagName @assets --repo $repo --clobber
+          } else {
+            Write-Host "Creating GitHub Release $tagName"
+            $notes = @(
+              "LDK $version release assets."
+              ""
+              "- ldk.$version.nupkg: offline NuGet package"
+              "- ldk-$version-prebuilt.zip: headers, docs, CMake helpers/package config, native MSBuild imports, and prebuilt x86/x64 Debug/Release libraries"
+              "- ldk-$version-SHA256SUMS.txt: SHA-256 checksums"
+            ) -join [Environment]::NewLine
+            & gh release create $tagName @assets --repo $repo --target '${{ github.sha }}' --title "LDK $version" --notes $notes
+          }
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "GitHub Release upload failed with exit code $LASTEXITCODE."
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,101 +1,74 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag. Defaults to v<version.h>; update version.h first when using the default.'
-        required: false
+      version:
+        description: Release version, for example 0.7.6
+        required: true
         type: string
+      publish:
+        description: Publish the generated package to nuget.org
+        required: true
+        type: boolean
+        default: true
+      github_release:
+        description: Upload release assets to GitHub Releases
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
-  metadata:
-    name: Metadata
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.meta.outputs.tag }}
-      version: ${{ steps.meta.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Compute release metadata
-        id: meta
-        shell: bash
-        run: |
-          major=$(sed -n 's/^#define LDK_VERSION_MAJOR[[:space:]]\+\([0-9]\+\)$/\1/p' include/Ldk/internal/version.h)
-          minor=$(sed -n 's/^#define LDK_VERSION_MINOR[[:space:]]\+\([0-9]\+\)$/\1/p' include/Ldk/internal/version.h)
-          patch=$(sed -n 's/^#define LDK_VERSION_PATCH[[:space:]]\+\([0-9]\+\)$/\1/p' include/Ldk/internal/version.h)
-          version="${major}.${minor}.${patch}"
-
-          if [[ -n "${{ inputs.tag }}" ]]; then
-            tag="${{ inputs.tag }}"
-          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            tag="${GITHUB_REF_NAME}"
-          else
-            tag="v${version}"
-          fi
-
-          echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
-          echo "tag=${tag}" | tee -a "$GITHUB_OUTPUT"
-
-  build:
-    name: Build ${{ matrix.arch }}
-    needs: [metadata]
+  release:
+    name: Prepare release and dispatch package workflow
     runs-on: windows-2022
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x86, x64]
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
 
-      - name: Build library
-        shell: cmd
-        run: build.bat . ${{ matrix.arch }} Release
-
-      - name: Package
+      - name: Configure release checkout
         shell: pwsh
         run: |
-          $tag = "${{ needs.metadata.outputs.tag }}"
-          $packageName = "ldk-$tag-${{ matrix.arch }}"
-          $stage = Join-Path $env:RUNNER_TEMP $packageName
-          New-Item -ItemType Directory -Force -Path $stage | Out-Null
-          Copy-Item -Recurse -Path "include" -Destination (Join-Path $stage "include")
-          New-Item -ItemType Directory -Force -Path (Join-Path $stage "lib") | Out-Null
-          Copy-Item -Recurse -Path "lib\${{ matrix.arch }}" -Destination (Join-Path $stage "lib")
-          Copy-Item -Path "README.md", "LICENSE" -Destination $stage
-          New-Item -ItemType Directory -Force -Path "dist" | Out-Null
-          Compress-Archive -Path (Join-Path $stage "*") -DestinationPath "dist\$packageName.zip" -Force
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git fetch origin main --tags
+          git checkout -B main origin/main
 
-      - name: Upload package
-        uses: actions/upload-artifact@v7
-        with:
-          name: package-${{ matrix.arch }}
-          path: dist/*.zip
+      - name: Create version commit and tag
+        shell: pwsh
+        run: ./scripts/release/Prepare-LdkRelease.ps1 -Version '${{ inputs.version }}' -Push
 
-  release:
-    name: Publish GitHub Release
-    needs: [metadata, build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download packages
-        uses: actions/download-artifact@v8
-        with:
-          path: dist
-          merge-multiple: true
+      - name: Dispatch Package workflow
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $version = '${{ inputs.version }}'
+          $publish = '${{ inputs.publish }}'.ToLowerInvariant()
+          $githubRelease = '${{ inputs.github_release }}'.ToLowerInvariant()
+          $tagName = "v$version"
 
-      - name: Publish release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.metadata.outputs.tag }}
-          target_commitish: ${{ github.sha }}
-          generate_release_notes: true
-          files: dist/*.zip
+          for ($attempt = 1; $attempt -le 6; $attempt++) {
+            Write-Host "Dispatching Package workflow for $tagName (attempt $attempt)"
+            & gh workflow run package.yml `
+              --repo '${{ github.repository }}' `
+              --ref $tagName `
+              -f publish=$publish `
+              -f github_release=$githubRelease
+
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Package workflow dispatch requested for $tagName."
+              exit 0
+            }
+
+            Start-Sleep -Seconds 10
+          }
+
+          throw "Package workflow dispatch failed for $tagName."

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,9 @@
 
 test/build*/
 build*/
+!nuget/build/
+!nuget/build/native/
+!nuget/build/native/*.props
+!nuget/build/native/*.targets
 lib/
+artifacts/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /WX")
 
 file(GLOB SOURCE_FILES ./src/*.c ./src/*/*.c ./src/ntdll/rtl/*.c)
+list(APPEND SOURCE_FILES
+    ./src/ntdll/alert.c
+    ./src/ntdll/waitonaddress.c
+)
+list(REMOVE_DUPLICATES SOURCE_FILES)
 
 wdk_add_library(Ldk STATIC ${SOURCE_FILES})
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ be done manually in an appropriate Windows driver test environment. GitHub
 Actions verifies the x64 test driver build, but it does not load kernel
 drivers.
 
+Additional implementation and test notes live under [`docs/`](docs/).
+
 ## Releases
 
 Tagged releases are built by GitHub Actions. Pushing a tag such as `v0.7.6`

--- a/README.md
+++ b/README.md
@@ -177,23 +177,32 @@ drivers.
 
 Additional implementation and test notes live under [`docs/`](docs/).
 
+## NuGet and Releases
+
+The `Package` GitHub Actions workflow builds prebuilt x86/x64 Debug/Release
+libraries, packs the `ldk` NuGet package, validates the package with a minimal
+WDK consumer driver, and prepares GitHub Release assets.
+
+The `Release` workflow is the publishing entry point. It updates
+`include/Ldk/internal/version.h`, creates a `v<version>` tag, then dispatches
+the `Package` workflow. NuGet publishing uses NuGet Trusted Publishing and
+requires the repository variable `NUGET_TRUSTED_PUBLISHING_USER`.
+
 ## Releases
 
 Tagged releases are built by GitHub Actions. Pushing a tag such as `v0.7.6`
-builds x86 and x64 Release artifacts and attaches ZIP packages to the GitHub
-Release.
+builds x86 and x64 package artifacts and can attach the generated NuGet package
+and prebuilt ZIP bundle to the GitHub Release.
 
-You can also run the release workflow manually from GitHub Actions. For manual
-runs, either provide an explicit tag input or update
-`include/Ldk/internal/version.h` first; otherwise the workflow derives the tag
-from the version header.
+The normal publishing path is to run the `Release` workflow manually with the
+target version. It creates the version commit and tag, then dispatches the
+`Package` workflow against that tag.
 
-Each release package contains:
+Release assets contain:
 
-- `include/`
-- `lib/<architecture>/`
-- `README.md`
-- `LICENSE`
+- `ldk.<version>.nupkg`
+- `ldk-<version>-prebuilt.zip`
+- `ldk-<version>-SHA256SUMS.txt`
 
 ## Repository Layout
 

--- a/cmake/Ldk.cmake
+++ b/cmake/Ldk.cmake
@@ -1,0 +1,193 @@
+if(NOT DEFINED LDK_USE_DRIVER_ENTRY)
+    set(LDK_USE_DRIVER_ENTRY ON)
+endif()
+
+if(DEFINED ldk_SOURCE_DIR)
+    set(_LDK_ROOT "${ldk_SOURCE_DIR}")
+elseif(DEFINED Ldk_SOURCE_DIR)
+    set(_LDK_ROOT "${Ldk_SOURCE_DIR}")
+elseif(DEFINED ldk_ROOT)
+    set(_LDK_ROOT "${ldk_ROOT}")
+elseif(DEFINED LDK_ROOT)
+    set(_LDK_ROOT "${LDK_ROOT}")
+else()
+    get_filename_component(_LDK_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+endif()
+
+if(NOT DEFINED LDK_USE_PREBUILT)
+    if(NOT TARGET Ldk AND EXISTS "${_LDK_ROOT}/lib/native")
+        set(LDK_USE_PREBUILT ON)
+    else()
+        set(LDK_USE_PREBUILT OFF)
+    endif()
+endif()
+
+if(EXISTS "${_LDK_ROOT}/cmake/CPM.cmake")
+    include("${_LDK_ROOT}/cmake/CPM.cmake")
+else()
+    set(CPM_DOWNLOAD_VERSION 0.32.0)
+
+    if(CPM_SOURCE_CACHE)
+        get_filename_component(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE} ABSOLUTE)
+        set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+    elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+        set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+    else()
+        set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+    endif()
+
+    if(NOT EXISTS ${CPM_DOWNLOAD_LOCATION})
+        message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+        file(DOWNLOAD
+            https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+            ${CPM_DOWNLOAD_LOCATION})
+    endif()
+
+    include(${CPM_DOWNLOAD_LOCATION})
+endif()
+
+CPMAddPackage("gh:ntoskrnl7/FindWDK#master")
+list(APPEND CMAKE_MODULE_PATH "${FindWDK_SOURCE_DIR}/cmake")
+find_package(WDK REQUIRED)
+
+function(ldk_import_wdk_libraries _version _out_imported)
+    file(GLOB _ldk_wdk_libraries "${WDK_ROOT}/Lib/${_version}/km/${WDK_PLATFORM}/*.lib")
+    if(NOT _ldk_wdk_libraries)
+        set(${_out_imported} OFF PARENT_SCOPE)
+        return()
+    endif()
+
+    foreach(_library IN LISTS _ldk_wdk_libraries)
+        get_filename_component(_library_name "${_library}" NAME_WE)
+        string(TOUPPER "${_library_name}" _library_name)
+
+        if(NOT TARGET WDK::${_library_name})
+            add_library(WDK::${_library_name} INTERFACE IMPORTED)
+        endif()
+
+        set_property(TARGET WDK::${_library_name} PROPERTY INTERFACE_LINK_LIBRARIES "${_library}")
+    endforeach()
+
+    set(${_out_imported} ON PARENT_SCOPE)
+endfunction()
+
+function(ldk_get_installed_wdk_library_versions _out_versions)
+    file(GLOB _ldk_wdk_library_dirs LIST_DIRECTORIES true "${WDK_ROOT}/Lib/*/km/${WDK_PLATFORM}")
+    set(_versions)
+
+    foreach(_library_dir IN LISTS _ldk_wdk_library_dirs)
+        get_filename_component(_km_dir "${_library_dir}" DIRECTORY)
+        get_filename_component(_version_dir "${_km_dir}" DIRECTORY)
+        get_filename_component(_version "${_version_dir}" NAME)
+        list(APPEND _versions "${_version}")
+    endforeach()
+
+    list(REMOVE_DUPLICATES _versions)
+    set(${_out_versions} "${_versions}" PARENT_SCOPE)
+endfunction()
+
+set(_LDK_WDK_VERSION_CANDIDATES)
+foreach(_version IN ITEMS
+        "${LDK_WDK_VERSION}"
+        "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
+        "${CMAKE_SYSTEM_VERSION}"
+        "${WDK_VERSION}")
+    if(NOT "${_version}" STREQUAL "")
+        list(APPEND _LDK_WDK_VERSION_CANDIDATES "${_version}")
+    endif()
+endforeach()
+ldk_get_installed_wdk_library_versions(_LDK_INSTALLED_WDK_LIBRARY_VERSIONS)
+list(APPEND _LDK_WDK_VERSION_CANDIDATES ${_LDK_INSTALLED_WDK_LIBRARY_VERSIONS})
+list(REMOVE_DUPLICATES _LDK_WDK_VERSION_CANDIDATES)
+
+foreach(_version IN LISTS _LDK_WDK_VERSION_CANDIDATES)
+    ldk_import_wdk_libraries("${_version}" _ldk_imported_wdk_libraries)
+    if(_ldk_imported_wdk_libraries)
+        if(NOT "${WDK_VERSION}" STREQUAL "${_version}")
+            if(EXISTS "${WDK_ROOT}/Include/${_version}/km/ntddk.h")
+                message(STATUS "Using WDK ${_version} headers and libraries for LDK CMake helpers")
+                set(WDK_VERSION "${_version}")
+            else()
+                message(STATUS "Using WDK ${_version} libraries with WDK ${WDK_VERSION} headers for LDK CMake helpers")
+            endif()
+        endif()
+
+        break()
+    endif()
+endforeach()
+
+if(NOT TARGET WDK::NTOSKRNL)
+    message(FATAL_ERROR "WDK::NTOSKRNL was not found for platform ${WDK_PLATFORM}. Set LDK_WDK_VERSION or CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION to an installed WDK version with kernel libraries.")
+endif()
+
+function(ldk_get_prebuilt_arch _out_arch)
+    if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
+        set(_arch x64)
+    elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
+        set(_arch x86)
+    else()
+        message(FATAL_ERROR "Unsupported LDK prebuilt platform: ${CMAKE_VS_PLATFORM_NAME}")
+    endif()
+
+    set(${_out_arch} "${_arch}" PARENT_SCOPE)
+endfunction()
+
+function(ldk_get_prebuilt_library _out_path _configuration)
+    ldk_get_prebuilt_arch(_arch)
+
+    if("${_configuration}" STREQUAL "Debug")
+        set(_config_dir Debug)
+    else()
+        set(_config_dir Release)
+    endif()
+
+    set(_path "${_LDK_ROOT}/lib/native/${_arch}/${_config_dir}/Ldk.lib")
+    file(TO_CMAKE_PATH "${_path}" _path)
+    if(NOT EXISTS "${_path}")
+        set(${_out_path} "" PARENT_SCOPE)
+        return()
+    endif()
+
+    set(${_out_path} "${_path}" PARENT_SCOPE)
+endfunction()
+
+function(ldk_link_prebuilt_libraries _target)
+    ldk_get_prebuilt_library(_ldk_debug Debug)
+    ldk_get_prebuilt_library(_ldk_release Release)
+
+    if(_ldk_debug AND _ldk_release)
+        target_link_libraries(
+            ${_target}
+            debug "${_ldk_debug}"
+            optimized "${_ldk_release}"
+        )
+    elseif(_ldk_debug)
+        target_link_libraries(${_target} "${_ldk_debug}")
+    elseif(_ldk_release)
+        target_link_libraries(${_target} "${_ldk_release}")
+    else()
+        message(FATAL_ERROR "No LDK prebuilt libraries were found under ${_LDK_ROOT}/lib/native for ${CMAKE_VS_PLATFORM_NAME}.")
+    endif()
+
+    target_include_directories(${_target} PUBLIC "${_LDK_ROOT}/include")
+    target_compile_definitions(${_target} PUBLIC "_KERNEL32_")
+    target_link_options(${_target} PUBLIC "/FORCE:MULTIPLE")
+endfunction()
+
+function(ldk_add_driver _target)
+    if(LDK_USE_DRIVER_ENTRY)
+        wdk_add_driver(${_target} CUSTOM_ENTRY_POINT LdkDriverEntry ${ARGN})
+    else()
+        wdk_add_driver(${_target} ${ARGN})
+    endif()
+
+    if(LDK_USE_PREBUILT)
+        ldk_link_prebuilt_libraries(${_target})
+    else()
+        if(NOT TARGET Ldk)
+            message(FATAL_ERROR "Ldk target was not found. Add LDK with CPMAddPackage or use an unpacked LDK native release bundle.")
+        endif()
+
+        target_link_libraries(${_target} Ldk)
+    endif()
+endfunction()

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# LDK documentation
+
+This directory contains implementation notes that are too detailed for the
+top-level README.
+
+Start here:
+
+- [Architecture](architecture.md): initialization, module registration, and
+  runtime component layout.
+- [API support](api-support.md): supported API areas and current caveats.
+- [Testing](testing.md): test driver structure, manual load expectations, and
+  stress-test guidance.
+
+Runtime areas:
+
+- [Runtime state](runtime-state.md): LDK PEB/TEB state, last-error storage,
+  TLS/FLS, and current thread identity.
+- [Loader](loader.md): `LoadLibrary`, `GetProcAddress`, `LdrLoadDll`, import
+  resolution, and unload behavior.
+- [Synchronization](synchronization.md): critical sections, SRW locks,
+  condition variables, waits, keyed events, and wait-on-address overview.
+- [Wait-on-address synchronization](wait-on-address.md): detailed
+  `WaitOnAddress` / `RtlWaitOnAddress` / alert-by-thread-id notes.
+- [Keyed events](keyed-event.md): current keyed-event implementation notes and
+  limitations.
+- [Threading and callbacks](threading-and-callbacks.md): `CreateThread`,
+  `ExitThread`, FLS callbacks, and threadpool behavior.
+- [Environment and paths](environment-and-paths.md): process parameters,
+  environment variables, current directory, and DLL search path behavior.
+
+LDK is intentionally incomplete. These notes describe the current runtime
+behavior and test coverage; they are not a compatibility promise for every
+Win32 or NTDLL API.

--- a/docs/api-support.md
+++ b/docs/api-support.md
@@ -1,0 +1,53 @@
+# API support
+
+LDK exposes a selected Win32/NTDLL-like surface for kernel-mode code. The table
+below is a practical map of the current implementation, not a promise of full
+Windows compatibility.
+
+Status guide:
+
+- Supported: implemented and covered by in-tree tests or simple wrappers over
+  kernel primitives.
+- Partial: useful, but intentionally narrower than Windows.
+- Experimental: works for the tested LDK scenarios, but needs extra validation
+  before relying on it in a driver.
+
+## Kernel32-style surface
+
+| Area | Representative APIs | Status | Notes |
+| --- | --- | --- | --- |
+| Loader | `LoadLibraryA/W`, `LoadLibraryExA/W`, `FreeLibrary`, `GetProcAddress`, `GetModuleHandleA/W`, `GetModuleFileNameA/W` | Experimental | Kernel-space DLL loading is the project core, but loaded modules must be audited. See [Loader](loader.md). |
+| Runtime state | `GetLastError`, `SetLastError`, `GetStartupInfoA/W`, `GetCurrentProcess`, `GetCurrentThread` | Partial | State is backed by LDK PEB/TEB records, not user-mode process state. |
+| Environment and paths | `GetEnvironmentVariableA/W`, `SetEnvironmentVariableA/W`, `GetEnvironmentStringsA/W`, `GetCurrentDirectoryA/W`, `SetCurrentDirectoryA/W`, `GetCommandLineA/W` | Partial | Backed by `RTL_USER_PROCESS_PARAMETERS` inside the LDK PEB. See [Environment and paths](environment-and-paths.md). |
+| Synchronization | Critical sections, condition variables, waits, `Sleep`, `WaitOnAddress`, `WakeByAddressSingle`, `WakeByAddressAll` | Partial | Common paths are tested, including multi-threaded wait-on-address stress. See [Synchronization](synchronization.md). |
+| Threads | `CreateThread`, `OpenThread`, `ExitThread`, `GetExitCodeThread`, `GetThreadTimes`, priority helpers | Partial | Uses kernel system threads. `CREATE_SUSPENDED` is not supported. See [Threading and callbacks](threading-and-callbacks.md). |
+| FLS | `FlsAlloc`, `FlsFree`, `FlsGetValue`, `FlsSetValue` | Partial | Stored in LDK TEB records. Callback lifetime is tied to thread exit and LDK teardown. |
+| Threadpool | `QueueUserWorkItem`, `CreateThreadpoolWork`, `SubmitThreadpoolWork`, `WaitForThreadpoolWorkCallbacks`, `CloseThreadpoolWork`, `FreeLibraryWhenCallbackReturns` | Partial | Implemented over kernel work items. Custom callback environments are not supported. |
+| Heap | `HeapCreate`, `HeapDestroy`, `HeapAlloc`, `HeapFree`, `HeapReAlloc`, `GetProcessHeap`, `HeapSize`, `HeapValidate`, `HeapCompact`, `HeapWalk`, `HeapQueryInformation` | Partial | `GetProcessHeap` returns the heap created for the LDK PEB. |
+| File and handles | `CreateFileA/W`, `ReadFile`, `WriteFile`, `FlushFileBuffers`, `CloseHandle`, `DuplicateHandle`, `CreatePipe`, `PeekNamedPipe` | Partial | Intended for controlled kernel-mode paths, not broad user-mode I/O compatibility. |
+| Console | `GetConsoleCP`, `GetConsoleOutputCP`, `GetConsoleMode`, `SetConsoleMode`, `ReadConsoleA/W`, `WriteConsoleA/W`, `SetConsoleCtrlHandler`, `SetConsoleCP`, `SetConsoleOutputCP` | Partial | Console devices are lightweight shims created during PEB initialization. |
+| Time and system info | `GetSystemTime`, `GetLocalTime`, `GetTickCount`, `GetTickCount64`, `GetSystemInfo`, `GetVersion`, `GlobalMemoryStatusEx`, time-zone helpers | Partial | Mostly thin kernel-backed helpers. |
+| NLS and strings | Code page, locale, and conversion helpers | Partial | Enough for current tests and loader/runtime conversions. |
+| Debug and exceptions | `IsDebuggerPresent`, `DebugBreak`, `OutputDebugStringA/W`, `RaiseException`, exception-filter helpers | Partial | Some paths are intentionally debugger-facing. |
+
+## NTDLL/RTL-style surface
+
+| Area | Representative APIs | Status | Notes |
+| --- | --- | --- | --- |
+| Loader | `LdrLoadDll`, `LdrUnloadDll`, `LdrGetProcedureAddress`, `LdrGetDllHandle` | Experimental | Wraps the LDK loader and module list. |
+| Synchronization | `RtlInitializeCriticalSection`, `RtlEnterCriticalSection`, `RtlLeaveCriticalSection`, condition-variable RTL APIs, SRW helpers | Partial | ReactOS-derived portions should be audited case by case. |
+| Wait-on-address | `RtlWaitOnAddress`, `RtlWakeAddressSingle`, `RtlWakeAddressAll` | Partial | Uses LDK alert-by-thread-id primitives internally. |
+| Native alert wait | `NtAlertThreadByThreadId`, `NtWaitForAlertByThreadId`, `Zw*` aliases | Partial | Pending alerts are keyed by the target `PETHREAD` object to avoid stale thread-id reuse. |
+| Keyed events | `NtCreateKeyedEvent`, `NtOpenKeyedEvent`, `NtWaitForKeyedEvent`, `NtReleaseKeyedEvent` | Partial | Implemented and tested, but currently not listed in the NTDLL pseudo-module registration table. |
+| Paths and environment | `RtlGetCurrentDirectory_U`, `RtlSetCurrentDirectory_U`, `RtlQueryEnvironmentVariable_U`, `RtlSetEnvironmentVariable`, DOS path helpers | Partial | Backed by LDK process parameters. |
+| Work items | `RtlQueueWorkItem` | Partial | Used by `QueueUserWorkItem`. |
+
+## General caveats
+
+LDK does not implement GUI APIs, COM, normal user-mode process startup, broad
+CRT assumptions, or arbitrary DLL behavior. Treat every loaded DLL as kernel
+code and validate it with the same standard as a driver.
+
+For exact declarations, use the headers under `include/Ldk`. For loader-visible
+exports, check the registration tables in `src/kernel32/kernel32.c` and
+`src/ntdll/ntdll.c`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,81 @@
+# Architecture
+
+LDK provides a small Win32/NTDLL-like runtime surface for kernel-mode code. It
+is built as a static WDK library and is initialized by the driver that links it.
+
+The project is not a full Windows compatibility layer. Each API is implemented
+only when the kernel-mode behavior can be bounded and tested.
+
+Related detail pages:
+
+- [Runtime state](runtime-state.md)
+- [Loader](loader.md)
+- [Synchronization](synchronization.md)
+- [Threading and callbacks](threading-and-callbacks.md)
+- [Environment and paths](environment-and-paths.md)
+- [API support](api-support.md)
+
+## Initialization
+
+Drivers normally use `LdkDriverEntry` as the custom entry point. That lets LDK
+run its startup and shutdown hooks around the driver's entry point and unload
+routine. Drivers with their own entry point can call `LdkInitialize` during
+startup and `LdkTerminate` before unload.
+
+The current initialization flow is:
+
+1. Heap list setup.
+2. PEB-like process state setup.
+3. TEB map setup for kernel threads that enter LDK code.
+4. NTDLL component initialization.
+5. Kernel32 component initialization.
+
+Termination runs the reverse side of that flow. It also marks shutdown in
+progress before unregistering modules and draining runtime components, so new
+waiters can reject work instead of blocking while the driver is unloading.
+
+## Runtime state
+
+LDK maintains lightweight PEB/TEB-style state for kernel-mode callers:
+
+- The PEB-like state owns module lists, loader state, process heap state, and
+  process-style environment/current-directory data.
+- The TEB-like state stores per-thread last-error values, TLS/FLS slots,
+  static conversion buffers, keyed-event wait data, and thread identity.
+
+Kernel threads do not have normal user-mode TEBs, so LDK maps `PETHREAD`
+objects to LDK TEB records and also caches the current TEB on the thread stack
+when possible.
+
+## Module registration
+
+LDK registers small export tables for its Kernel32 and NTDLL surfaces. Loader
+helpers use those registrations to resolve supported imports for DLLs or code
+that expects familiar API names.
+
+The major runtime areas are:
+
+- `src/kernel32/`: selected Kernel32-style APIs.
+- `src/ntdll/`: selected NTDLL-style APIs and RTL helpers.
+- `src/peb.c` and `src/teb.c`: process/thread runtime state.
+- `src/ldk.c`: initialization, termination, module registration, and unload
+  coordination.
+
+## API areas
+
+The implemented surface is intentionally partial, but it covers several common
+runtime categories:
+
+- File and handle helpers.
+- Console shims.
+- Heap helpers.
+- Environment and current-directory helpers.
+- Critical sections, condition variables, keyed events, and selected wait
+  primitives.
+- Thread creation and basic process/thread information helpers.
+- FLS/TLS and fiber-related helpers.
+- Loader helpers such as `LoadLibrary`, `GetProcAddress`, and module lookup.
+- Time, NLS, string conversion, and utility helpers.
+
+Unsupported user-mode subsystems such as GUI APIs, COM, broad CRT startup
+behavior, and arbitrary user-mode assumptions should not be expected to work.

--- a/docs/environment-and-paths.md
+++ b/docs/environment-and-paths.md
@@ -1,0 +1,63 @@
+# Environment and paths
+
+LDK stores environment, current-directory, command-line, and DLL search path
+state in the process parameters owned by the LDK PEB.
+
+## Initial state
+
+During PEB initialization, LDK creates `RTL_USER_PROCESS_PARAMETERS` and seeds:
+
+- Standard input, output, and error handles.
+- `ImagePathName` from the loaded driver image path.
+- `CommandLine` from the image path.
+- `CurrentDirectory` from `NtSystemRoot`.
+- `DllPath` from the system directory.
+- Environment variables including `windir`, `SystemDrive`, `SystemRoot`, and
+  `PATH`.
+
+The standard handles are backed by lightweight console device objects. They are
+useful for compatibility with code that expects the fields to exist, not for
+full console semantics.
+
+## Environment APIs
+
+Kernel32 environment APIs call into the RTL environment helpers and the LDK
+process parameters:
+
+- `GetEnvironmentStrings` / `GetEnvironmentStringsW`
+- `FreeEnvironmentStringsA/W`
+- `GetEnvironmentVariableA/W`
+- `SetEnvironmentVariableA/W`
+
+ANSI variants convert through LDK string helpers and the current TEB's static
+conversion buffers where appropriate.
+
+When an environment variable is missing, the APIs follow Win32-style behavior:
+the call fails, the returned length is zero, and the last error is set from the
+underlying status mapping.
+
+## Current directory APIs
+
+`GetCurrentDirectoryA/W` and `SetCurrentDirectoryA/W` use
+`RtlGetCurrentDirectory_U` and `RtlSetCurrentDirectory_U`.
+
+`SetCurrentDirectoryA` accepts a quoted path retry path for compatibility with
+callers that accidentally include a leading quote. The current directory is
+stored in the LDK process parameters and guarded with the PEB lock where needed.
+
+## DLL search path
+
+The loader uses process-parameter path state when loading DLLs. `LoadLibraryExW`
+computes a DLL path from `PATH` and the current image directory before calling
+`LdrLoadDll`.
+
+`LdkLoadDll` ultimately uses `RtlDosSearchPath_U` and DOS-to-NT path conversion
+before opening the target file.
+
+## Caveats
+
+This state is private to LDK. It is not the host process environment, and it is
+not synchronized with user-mode process parameters. Code that expects shell
+environment variables, per-user profile expansion, drive-current-directory
+slots, or process-wide user-mode loader state needs additional compatibility
+work.

--- a/docs/keyed-event.md
+++ b/docs/keyed-event.md
@@ -1,0 +1,49 @@
+# Keyed events
+
+LDK contains a small native keyed-event implementation used by synchronization
+code and covered by the NTDLL keyed-event tests.
+
+Implemented APIs:
+
+- `NtCreateKeyedEvent`
+- `NtOpenKeyedEvent`
+- `NtWaitForKeyedEvent`
+- `NtReleaseKeyedEvent`
+
+## Implementation
+
+`NtCreateKeyedEvent` and `NtOpenKeyedEvent` currently wrap kernel event object
+creation/opening while forcing kernel handles through object attributes.
+
+Waiters are represented by entries in an internal wait list. Each entry stores:
+
+- The wait key.
+- The waiting LDK TEB.
+
+`NtWaitForKeyedEvent` inserts the current thread's TEB into the list, pulses the
+backing event handle, stores the keyed wait value in the TEB, then waits on the
+TEB's keyed-wait semaphore.
+
+`NtReleaseKeyedEvent` searches the wait list for a matching key. If it finds a
+waiter, it removes that entry, releases the waiter's semaphore, and pulses the
+backing event.
+
+## Teardown
+
+The NTDLL component initializes the keyed-event wait list before condition
+variables and related synchronization code are initialized. During teardown, it
+walks remaining wait entries, releases any still-associated TEB semaphores, and
+frees the list entries before deleting the lookaside list.
+
+## Current caveats
+
+The implementation is intentionally small and should not be treated as a full
+Windows keyed-event clone. In particular:
+
+- The APIs are declared and implemented, but they are not currently listed in
+  the NTDLL pseudo-module registration table.
+- Timeout and alertable edge cases should be audited before widening use.
+- The implementation is tied to the LDK TEB model.
+
+Use the existing tests as a regression baseline, then add targeted stress tests
+before relying on keyed events for new runtime behavior.

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -1,0 +1,71 @@
+# Loader
+
+DLL loading is the center of LDK's design. The loader provides enough
+Win32/NTDLL-shaped behavior for controlled DLLs to be loaded and resolved in
+kernel space.
+
+## Public layers
+
+The call stack is intentionally familiar:
+
+- Kernel32 wrappers: `LoadLibraryA/W`, `LoadLibraryExA/W`, `FreeLibrary`,
+  `GetProcAddress`, `GetModuleHandleA/W`, `GetModuleFileNameA/W`.
+- NTDLL wrappers: `LdrLoadDll`, `LdrUnloadDll`, `LdrGetProcedureAddress`,
+  `LdrGetDllHandle`.
+- LDK core: module list lookup, PE loading, import resolution, relocation,
+  entry-point invocation, and unload.
+
+The Kernel32 and NTDLL pseudo modules are registered during PEB initialization.
+Those registrations let loaded code resolve supported imports by name.
+
+## Load path
+
+`LoadLibraryExW` first checks whether the module is already known. It also
+handles the current image path case and computes a DLL search path from the
+current `PATH` plus the image directory.
+
+`LdrLoadDll` forwards to `LdkLoadDll`, unless loader initialization is already
+in progress. The core load path:
+
+1. Searches the DLL path using RTL DOS path helpers.
+2. Converts the DOS path to an NT path.
+3. Opens and reads the image file.
+4. Validates PE headers, architecture, and DLL characteristics.
+5. Allocates nonpaged memory for the image.
+6. Copies headers and sections.
+7. Applies base relocations.
+8. Resolves imports through the LDK module list.
+9. Registers the loaded module.
+10. Calls the DLL entry point with `DLL_PROCESS_ATTACH`.
+
+Entry points are called through a kernel stack expansion helper when needed.
+
+## Import and export resolution
+
+Imports are resolved by module name and imported function name. Import-by-ordinal
+in import descriptors is not currently supported.
+
+`GetProcAddress` calls `LdrGetProcedureAddress`. For LDK pseudo modules, the
+resolver searches the registration table. For real PE images, it walks the PE
+export directory. Forwarded exports are followed by loading the forwarder
+module and resolving the forwarded symbol.
+
+Ordinal export lookup exists in the resolver path, but name-based resolution is
+the better-tested path.
+
+## Unload path
+
+`FreeLibrary` calls `LdrUnloadDll`, which calls `LdkUnloadDll`. Loaded modules
+are removed from the module list, called with `DLL_PROCESS_DETACH`, and freed.
+
+`LdkTerminate` unregisters remaining modules before tearing down Kernel32,
+NTDLL, TEB, PEB, and heap state. This matters because loaded DLLs can run detach
+code that touches LDK runtime services.
+
+## Limits
+
+LDK loading is not user-mode Windows loading. Loaded DLLs run as kernel code.
+Avoid DLLs that require GUI state, COM, arbitrary CRT startup, user-mode TLS
+callbacks, user-mode APC assumptions, or unsupported imports. Treat import
+failures and debugger breaks in loader paths as compatibility bugs to audit, not
+as recoverable normal behavior.

--- a/docs/runtime-state.md
+++ b/docs/runtime-state.md
@@ -1,0 +1,87 @@
+# Runtime state
+
+Kernel threads do not have user-mode PEB and TEB records. LDK creates a small
+PEB/TEB-like runtime so code that expects selected Win32 and NTDLL state has a
+controlled place to read and write it.
+
+## Initialization
+
+`LdkInitialize` creates runtime state in this order:
+
+1. Heap list.
+2. PEB-like process state.
+3. TEB map.
+4. NTDLL components.
+5. Kernel32 components.
+
+`LdkTerminate` marks shutdown in progress, unregisters modules, terminates
+Kernel32 and NTDLL components, tears down the TEB map, then destroys the PEB and
+heap list.
+
+## PEB-like state
+
+`LdkCurrentPeb()` returns the global LDK PEB record. It owns:
+
+- Driver object and image information.
+- Process heap.
+- Module list and module-list resource.
+- Process parameters.
+- TLS and FLS allocation bitmaps.
+- FLS callback table.
+
+The initial module list contains LDK's Kernel32 and NTDLL pseudo modules. DLLs
+loaded through the loader are added to the same list.
+
+## Process parameters
+
+LDK initializes `RTL_USER_PROCESS_PARAMETERS` with:
+
+- Standard input, output, and error handles backed by lightweight console
+  device objects.
+- Image path and command line derived from the loaded driver image.
+- Current directory rooted at `NtSystemRoot`.
+- DLL path and `PATH` seeded from the system directory.
+- Environment entries such as `windir`, `SystemDrive`, and `SystemRoot`.
+
+Environment, current-directory, command-line, and startup-info APIs read from
+this state.
+
+## TEB-like state
+
+LDK maps `PETHREAD` objects to LDK TEB records. `LdkCurrentTeb()` first checks a
+cached pointer stored near the current stack limit. If that cache cannot be used
+for example after a kernel stack expansion, it looks up the current `PETHREAD`
+in the TEB map and refreshes the cache.
+
+Each LDK TEB stores:
+
+- A pointer back to the LDK PEB.
+- The owning `PETHREAD`.
+- Client id values.
+- Last-error and status-related state.
+- Static string conversion buffers.
+- TLS/FLS slots.
+- Keyed-event and alert-by-thread-id wait state.
+
+During shutdown, new TEB creation falls back to a temporary list so teardown
+paths that still touch TEB state can complete without re-entering the normal
+TEB map.
+
+## TLS, FLS, and last error
+
+TLS and FLS indexes are allocated from bitmaps in the LDK PEB. Per-thread slot
+values live in the current LDK TEB.
+
+FLS callbacks are invoked when an LDK-created thread exits and again during TEB
+map teardown for remaining TEBs. LDK invokes a callback only when both the
+registered callback and slot data are non-null.
+
+`GetLastError` and `SetLastError` are thread-local through the LDK TEB. They do
+not interact with any user-mode TEB.
+
+## Practical notes
+
+LDK runtime state is process-like, but it is not the real user-mode process
+environment. Code that assumes user-mode loader state, a real user TEB, GUI
+thread state, APC behavior, or normal CRT startup should be treated as
+unsupported until specifically audited and tested.

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -1,0 +1,65 @@
+# Synchronization
+
+LDK implements selected Kernel32, RTL, and native synchronization primitives for
+kernel-mode callers.
+
+## Implemented areas
+
+The current synchronization surface includes:
+
+- Critical sections: `InitializeCriticalSection`, `EnterCriticalSection`,
+  `LeaveCriticalSection`, `DeleteCriticalSection`, and RTL equivalents.
+- SRW locks: public declarations and RTL-backed helpers.
+- Condition variables: Kernel32 wrappers and RTL condition-variable routines.
+- Waits and delay: `WaitForSingleObject`, `WaitForMultipleObjects`,
+  alertable variants, `Sleep`, and `SleepEx`.
+- One-time initialization: `InitOnceExecuteOnce`.
+- Keyed events: `NtCreateKeyedEvent`, `NtOpenKeyedEvent`,
+  `NtWaitForKeyedEvent`, and `NtReleaseKeyedEvent`.
+- Wait-on-address: `WaitOnAddress`, `WakeByAddressSingle`,
+  `WakeByAddressAll`, and RTL equivalents.
+- Native alert wait: `NtAlertThreadByThreadId` and
+  `NtWaitForAlertByThreadId`.
+
+The detail pages are:
+
+- [Wait-on-address synchronization](wait-on-address.md)
+- [Keyed events](keyed-event.md)
+
+## Layering
+
+Kernel32 APIs generally translate Win32-style parameters and errors to the RTL
+or native layer. NTDLL/RTL functions own the lower-level state and return
+`NTSTATUS`.
+
+The wait-on-address implementation is layered as:
+
+`WaitOnAddress` -> `RtlWaitOnAddress` -> `NtWaitForAlertByThreadId`
+
+Wake calls follow the reverse direction through address wait-list lookup and
+`NtAlertThreadByThreadId`.
+
+Condition variables and critical sections use the NTDLL synchronization code
+and keyed-event support initialized by the NTDLL component.
+
+## Shutdown behavior
+
+Synchronization code must be unload-aware. During `LdkTerminate`, shutdown is
+marked before runtime components are drained. The wait-on-address layer tracks
+active waiters so teardown can avoid freeing wait-list state while threads are
+still blocked in it. Keyed-event teardown releases waiters that remain on the
+internal list.
+
+## Testing
+
+The test driver currently covers:
+
+- Condition variables and critical sections.
+- Keyed events.
+- Wait-on-address single wake, wake-all, timeout, multiple address sizes, mixed
+  address sets, direct RTL waits, native alert waits, and durability loops.
+
+For new synchronization work, add both a narrow behavior test and at least one
+multi-threaded stress case. Driver Verifier and repeated load/unload runs are
+still recommended for changes that touch wait lists, thread lifetime, or
+teardown paths.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,64 @@
+# Testing
+
+The `test` directory builds `LdkTest.sys`, a kernel driver that links against
+LDK and exercises the runtime from `DriverEntry`.
+
+GitHub Actions verifies that the test driver builds, but kernel driver loading
+must be done manually in an isolated Windows driver test environment.
+
+## Test driver flow
+
+`test/driver.c` runs test routines one by one and logs each result with a stable
+name:
+
+- `[LdkTest] RUN  <name>`
+- `[LdkTest] PASS <name>`
+- `[LdkTest] FAIL <name>`
+
+If a test fails, `DriverEntry` calls `LdkTerminate` and returns failure so the
+service start fails instead of leaving a partially tested driver loaded.
+
+The current test suite covers:
+
+- NTDLL current-directory and environment helpers.
+- Keyed events.
+- Loader helpers.
+- Fibers and FLS callbacks.
+- File helpers.
+- Kernel32 current-directory and environment helpers.
+- Legacy and newer threadpool helpers.
+- Condition variables and critical sections.
+- Wait-on-address synchronization.
+- Library loading helpers.
+- Console helpers.
+
+## Debugger behavior
+
+The test driver intentionally contains debugger breakpoints in some paths. When
+running under WinDbg/KD, continue execution after expected breakpoints before
+judging the test result.
+
+The service control result is the final pass/fail signal:
+
+- `sc start` success and service state `RUNNING` means all tests reached the
+  end of `DriverEntry`.
+- `sc start` failure with `[LdkTest] FAIL <name>` in debugger output identifies
+  the failing test.
+- A bugcheck or stuck `START_PENDING` state should be treated as a runtime
+  failure even if no explicit `[LdkTest] FAIL` line was printed.
+
+## Stress guidance
+
+The in-tree tests are designed to catch common regressions quickly. For changes
+to synchronization, loader, or thread lifetime behavior, also run additional
+manual validation when possible:
+
+- Repeated load/unload loops.
+- Driver Verifier with pool, IRQL, and deadlock-related checks.
+- Longer mixed-operation stress runs.
+- Tests on the oldest and newest Windows versions the project intends to
+  support.
+
+Any new runtime primitive should include a narrow success test, timeout or
+failure-path coverage when applicable, and at least one multi-threaded test if
+the implementation owns shared state.

--- a/docs/threading-and-callbacks.md
+++ b/docs/threading-and-callbacks.md
@@ -1,0 +1,66 @@
+# Threading and callbacks
+
+LDK implements a narrow thread and callback surface for kernel-mode code that
+expects selected Kernel32 behavior.
+
+## CreateThread
+
+`CreateThread` creates a kernel system thread with `PsCreateSystemThread`. The
+thread start routine receives the caller's parameter and its return value is
+used as the system-thread exit status. That lets `GetExitCodeThread` observe the
+start routine result through `ThreadBasicInformation`.
+
+If the requested stack size is larger than the remaining kernel stack, LDK runs
+the start routine through `KeExpandKernelStackAndCallout`. The heap-allocated
+thread context is released before entering the callout path so an `ExitThread`
+inside the start routine does not leak that context.
+
+`CREATE_SUSPENDED` is not supported.
+
+## ExitThread and FLS callbacks
+
+`ExitThread` invokes FLS callbacks for the current LDK TEB, then terminates the
+system thread with `PsTerminateSystemThread`.
+
+FLS callback rules in LDK:
+
+- Callback pointers are stored in the LDK PEB.
+- Per-thread FLS data lives in the LDK TEB.
+- A callback is invoked only when both the callback pointer and slot data are
+  non-null.
+- Slot data is exchanged to `NULL` before invoking the callback.
+
+During `LdkTerminate`, the TEB map is moved to a temporary list before FLS
+callbacks are invoked. That avoids holding the TEB list lock while callback code
+runs.
+
+## Thread identity and handles
+
+`GetCurrentThread` returns the current thread pseudo handle. `GetCurrentThreadId`
+uses `PsGetCurrentThreadId`. `OpenThread`, priority helpers, `GetThreadTimes`,
+and `GetExitCodeThread` are thin wrappers over native thread information calls.
+
+The LDK TEB stores client-id values for APIs that need process/thread identity,
+but this is LDK-maintained state, not a user-mode TEB.
+
+## Threadpool
+
+The modern threadpool work APIs are implemented over kernel work items:
+
+- `CreateThreadpoolWork`
+- `SubmitThreadpoolWork`
+- `WaitForThreadpoolWorkCallbacks`
+- `CloseThreadpoolWork`
+- `FreeLibraryWhenCallbackReturns`
+
+`QueueUserWorkItem` uses `RtlQueueWorkItem`.
+
+Custom threadpool callback environments are not supported. The current
+implementation is suitable for controlled work callbacks in tests, not as a
+drop-in replacement for the full Windows threadpool.
+
+## Testing
+
+The test driver covers basic thread creation, FLS callback behavior, legacy
+work items, modern threadpool work items, and wait-on-address stress paths that
+create and join many worker threads.

--- a/docs/wait-on-address.md
+++ b/docs/wait-on-address.md
@@ -1,0 +1,63 @@
+# Wait-on-address synchronization
+
+This is the detailed note for the wait-on-address family. For the wider
+synchronization map, see [Synchronization](synchronization.md).
+
+LDK implements the Windows wait-on-address family for kernel-mode callers while
+keeping the public declarations close to the Windows SDK and NTDLL API shapes.
+
+Implemented APIs:
+
+- `WaitOnAddress`
+- `WakeByAddressSingle`
+- `WakeByAddressAll`
+- `RtlWaitOnAddress`
+- `RtlWakeAddressSingle`
+- `RtlWakeAddressAll`
+- `NtAlertThreadByThreadId`
+- `NtWaitForAlertByThreadId`
+
+## Implementation
+
+`WaitOnAddress` is a Kernel32 wrapper over `RtlWaitOnAddress`. The RTL
+implementation keeps a kernel-mode wait list keyed by the watched address and
+uses the native alert-by-thread-id primitive to wake blocked waiters.
+
+The native alert layer supports both direct waiters and alert-before-wait
+delivery. Pending alerts are keyed by the referenced target thread object, not
+only by the numeric thread id. This avoids delivering a stale pending alert to a
+later thread that happens to reuse the same thread id.
+
+Wait list and pending alert state are protected by spin locks. Active waiters
+are counted and drained during LDK termination so the driver is not unloaded
+while waiters are still blocked in LDK code.
+
+## Semantics
+
+As on Windows, a successful wake-up from `WaitOnAddress` does not mean the
+watched value has a particular new value. Callers must re-check their predicate
+after every wake and use the wait in a loop.
+
+`RtlWaitOnAddress` accepts address sizes of 1, 2, 4, and 8 bytes. Unsupported
+sizes fail with `STATUS_INVALID_PARAMETER`.
+
+`WaitOnAddress` returns `FALSE` for timeout and records the mapped last-error
+value. Other successful native wait completions return `TRUE`.
+
+## Test coverage
+
+The test driver includes multi-threaded coverage for:
+
+- Kernel32 `WaitOnAddress` / `WakeByAddressSingle` / `WakeByAddressAll`
+- direct `RtlWaitOnAddress` / `RtlWakeAddressSingle` / `RtlWakeAddressAll`
+- `NtAlertThreadByThreadId` / `NtWaitForAlertByThreadId`
+- timeout handling
+- wake-all and repeated wake-single behavior
+- multiple independent wait addresses
+- 1, 2, 4, and 8 byte address sizes
+- repeated create/wait/wake/exit durability rounds
+
+These tests are intended to catch missed wake-ups, stale pending alerts, address
+isolation bugs, timeout misreporting, and unload-time pending waiter issues.
+They are not a substitute for Driver Verifier or long-running soak tests in a
+target deployment environment.

--- a/include/Ldk/consoleapi.h
+++ b/include/Ldk/consoleapi.h
@@ -89,7 +89,7 @@ BOOL
 WINAPI
 ReadConsoleA(
     _In_ HANDLE hConsoleInput,
-    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(TCHAR%),*lpNumberOfCharsRead * sizeof(TCHAR%)) LPVOID lpBuffer,
+    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(CHAR),*lpNumberOfCharsRead * sizeof(CHAR)) LPVOID lpBuffer,
     _In_ DWORD nNumberOfCharsToRead,
     _Out_ _Deref_out_range_(<=,nNumberOfCharsToRead) LPDWORD lpNumberOfCharsRead,
     _In_opt_ PCONSOLE_READCONSOLE_CONTROL pInputControl
@@ -101,7 +101,7 @@ BOOL
 WINAPI
 ReadConsoleW(
     _In_ HANDLE hConsoleInput,
-    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(TCHAR%),*lpNumberOfCharsRead * sizeof(TCHAR%)) LPVOID lpBuffer,
+    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(WCHAR),*lpNumberOfCharsRead * sizeof(WCHAR)) LPVOID lpBuffer,
     _In_ DWORD nNumberOfCharsToRead,
     _Out_ _Deref_out_range_(<=,nNumberOfCharsToRead) LPDWORD lpNumberOfCharsRead,
     _In_opt_ PCONSOLE_READCONSOLE_CONTROL pInputControl

--- a/include/Ldk/ntdll/ntexapi.h
+++ b/include/Ldk/ntdll/ntexapi.h
@@ -44,6 +44,22 @@ NtReleaseKeyedEvent (
     _In_opt_ PLARGE_INTEGER Timeout
     );
 
+NTSTATUS
+NTAPI
+NtAlertThreadByThreadId (
+    _In_ HANDLE ThreadId
+    );
+
+NTSTATUS
+NTAPI
+NtWaitForAlertByThreadId (
+    _In_opt_ PVOID Address,
+    _In_opt_ PLARGE_INTEGER Timeout
+    );
+
+#define ZwAlertThreadByThreadId        NtAlertThreadByThreadId
+#define ZwWaitForAlertByThreadId       NtWaitForAlertByThreadId
+
 
 
 NTSYSAPI

--- a/include/Ldk/ntdll/nturtl.h
+++ b/include/Ldk/ntdll/nturtl.h
@@ -136,6 +136,27 @@ RtlSleepConditionVariableSRW(
     _In_ ULONG Flags
     );
 
+NTSTATUS
+NTAPI
+RtlWaitOnAddress(
+    _In_reads_bytes_(AddressSize) volatile VOID* Address,
+    _In_reads_bytes_(AddressSize) PVOID CompareAddress,
+    _In_ SIZE_T AddressSize,
+    _In_opt_ PLARGE_INTEGER Timeout
+    );
+
+VOID
+NTAPI
+RtlWakeAddressSingle(
+    _In_ PVOID Address
+    );
+
+VOID
+NTAPI
+RtlWakeAddressAll(
+    _In_ PVOID Address
+    );
+
 
 #define RTL_HEAP_MAKE_TAG HEAP_MAKE_TAG_FLAGS
 

--- a/include/Ldk/synchapi.h
+++ b/include/Ldk/synchapi.h
@@ -387,6 +387,30 @@ Sleep(
     _In_ DWORD dwMilliseconds
     );
 
+WINBASEAPI
+BOOL
+WINAPI
+WaitOnAddress(
+    _In_reads_bytes_(AddressSize) volatile VOID* Address,
+    _In_reads_bytes_(AddressSize) PVOID CompareAddress,
+    _In_ SIZE_T AddressSize,
+    _In_opt_ DWORD dwMilliseconds
+    );
+
+WINBASEAPI
+VOID
+WINAPI
+WakeByAddressSingle(
+    _In_ PVOID Address
+    );
+
+WINBASEAPI
+VOID
+WINAPI
+WakeByAddressAll(
+    _In_ PVOID Address
+    );
+
 EXTERN_C_END
 
 #endif // _SYNCHAPI_H_

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -1,0 +1,54 @@
+# LDK NuGet Package
+
+This package provides headers and prebuilt `Ldk.lib` libraries for Windows
+kernel-mode driver projects.
+
+The package is intentionally narrow. LDK is an experimental runtime support
+library, not a general Windows compatibility layer. Audit every DLL or driver
+integration and validate it in an isolated driver test environment.
+
+## Contents
+
+- `include/`: public LDK headers
+- `docs/`: implementation notes
+- `lib/native/<arch>/<config>/Ldk.lib`: prebuilt static libraries
+- `build/native/ldk.props` and `ldk.targets`: MSBuild integration
+
+Prebuilt libraries currently target:
+
+- `x86` and `x64`
+- `Debug` and `Release`
+- Visual Studio 2022 with Windows SDK/WDK `10.0.22621.0`
+
+## MSBuild usage
+
+Install the package into a WDK driver project and import the native props and
+targets if your package manager does not do it automatically:
+
+```xml
+<Import Project="$(LdkPackageRoot)build\native\ldk.props" />
+...
+<Import Project="$(LdkPackageRoot)build\native\ldk.targets" />
+```
+
+The targets add the package include directory, link `Ldk.lib`, define
+`_KERNEL32_`, and by default set the driver entry point to `LdkDriverEntry`.
+Your driver should still implement the normal `DriverEntry` function; LDK's
+entry point calls it after initializing the runtime.
+
+Set `LdkUseDriverEntry=false` before importing `ldk.targets` if your driver uses
+its own entry point and calls `LdkInitialize` / `LdkTerminate` manually.
+
+## CMake users
+
+For CMake-based integrations, using the repository through CPM is still the
+most direct source-based path:
+
+```cmake
+CPMAddPackage("gh:ntoskrnl7/ldk@<version>")
+wdk_add_driver(MyDriver CUSTOM_ENTRY_POINT "LdkDriverEntry" main.c)
+target_link_libraries(MyDriver Ldk)
+```
+
+GitHub Releases also include a prebuilt bundle with a CMake package config for
+offline or prebuilt-library consumers.

--- a/nuget/build/native/ldk.props
+++ b/nuget/build/native/ldk.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <LdkRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..'))</LdkRoot>
+  </PropertyGroup>
+</Project>

--- a/nuget/build/native/ldk.targets
+++ b/nuget/build/native/ldk.targets
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <LdkRoot Condition="'$(LdkRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..'))</LdkRoot>
+    <LdkIsDriverProject Condition="'$(LdkIsDriverProject)' == '' and ('$(ConfigurationType)' == 'Driver' or '$(DriverType)' != '')">true</LdkIsDriverProject>
+    <LdkIsDriverProject Condition="'$(LdkIsDriverProject)' == ''">false</LdkIsDriverProject>
+    <LdkUseDriverSupport Condition="'$(LdkUseDriverSupport)' == '' and '$(LdkIsDriverProject)' == 'true'">true</LdkUseDriverSupport>
+    <LdkUseDriverSupport Condition="'$(LdkUseDriverSupport)' == ''">false</LdkUseDriverSupport>
+    <LdkLibPlatform Condition="'$(LdkLibPlatform)' == '' and '$(Platform)' == 'Win32'">x86</LdkLibPlatform>
+    <LdkLibPlatform Condition="'$(LdkLibPlatform)' == ''">$(Platform)</LdkLibPlatform>
+    <LdkLibraryConfiguration Condition="'$(LdkLibraryConfiguration)' == '' and ('$(Configuration)' == 'Debug' or '$(Configuration)' == 'Release')">$(Configuration)</LdkLibraryConfiguration>
+    <LdkLibraryConfiguration Condition="'$(LdkLibraryConfiguration)' == ''">Release</LdkLibraryConfiguration>
+    <LdkLibDir Condition="'$(LdkLibDir)' == ''">$(LdkRoot)lib\native\$(LdkLibPlatform)\$(LdkLibraryConfiguration)\</LdkLibDir>
+    <LdkUseDriverEntry Condition="'$(LdkUseDriverEntry)' == ''">true</LdkUseDriverEntry>
+    <LdkDriverPreprocessorDefinitions Condition="'$(LdkDriverPreprocessorDefinitions)' == ''">_KERNEL32_</LdkDriverPreprocessorDefinitions>
+  </PropertyGroup>
+
+  <Target Name="LdkValidateNativePackage" BeforeTargets="PrepareForBuild">
+    <Error
+      Condition="'$(LdkUseDriverSupport)' == 'true' and '$(LdkLibPlatform)' != 'x86' and '$(LdkLibPlatform)' != 'x64'"
+      Text="LDK NuGet package contains prebuilt driver libraries for x86 and x64 only. Current platform is '$(Platform)'." />
+    <Error
+      Condition="'$(LdkUseDriverSupport)' == 'true' and !Exists('$(LdkLibDir)Ldk.lib')"
+      Text="Ldk.lib was not found under '$(LdkLibDir)'." />
+    <Message
+      Importance="high"
+      Condition="'$(LdkUseDriverSupport)' != 'true'"
+      Text="LDK NuGet package is not applying driver link settings because LdkUseDriverSupport is '$(LdkUseDriverSupport)'." />
+  </Target>
+
+  <ItemDefinitionGroup>
+    <ClCompile Condition="'$(LdkUseDriverSupport)' == 'true'">
+      <AdditionalIncludeDirectories>$(LdkRoot)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>$(LdkDriverPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link Condition="'$(LdkUseDriverSupport)' == 'true'">
+      <AdditionalLibraryDirectories>$(LdkLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Ldk.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <EntryPointSymbol Condition="'$(LdkUseDriverEntry)' == 'true'">LdkDriverEntry</EntryPointSymbol>
+      <AdditionalOptions>/FORCE:MULTIPLE %(AdditionalOptions)</AdditionalOptions>
+      <TreatLinkerWarningAsErrors>false</TreatLinkerWarningAsErrors>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/nuget/ldk.nuspec
+++ b/nuget/ldk.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>ldk</id>
+    <version>0.0.0</version>
+    <authors>ntoskrnl7</authors>
+    <title>LDK</title>
+    <description>Experimental Win32/NTDLL-like runtime support library for Windows kernel-mode drivers.</description>
+    <projectUrl>https://github.com/ntoskrnl7/ldk</projectUrl>
+    <repository type="git" url="https://github.com/ntoskrnl7/ldk" />
+    <license type="file">LICENSE</license>
+    <readme>README.md</readme>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>windows kernel driver wdk native c ldk dll loader cmake</tags>
+    <dependencies>
+      <group targetFramework="native0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="README.md" target="README.md" />
+    <file src="..\LICENSE" target="LICENSE" />
+    <file src="..\cmake\**\*" target="cmake" />
+    <file src="..\docs\**\*" target="docs" />
+    <file src="..\include\**\*" target="include" />
+    <file src="..\artifacts\nuget-staging\lib\native\**\*" target="lib\native" />
+
+    <file src="build\native\ldk.props" target="build\native" />
+    <file src="build\native\ldk.targets" target="build\native" />
+  </files>
+</package>

--- a/scripts/nuget/Build-LdkNuGetLibs.ps1
+++ b/scripts/nuget/Build-LdkNuGetLibs.ps1
@@ -1,0 +1,89 @@
+param(
+  [ValidateSet('x86', 'x64')]
+  [string[]] $Architecture = @('x86', 'x64'),
+
+  [ValidateSet('Debug', 'Release')]
+  [string[]] $Configuration = @('Debug', 'Release'),
+
+  [string] $WindowsSdkVersion = '10.0.22621.0',
+
+  [string] $OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+  $OutputDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
+}
+
+$platformByArchitecture = @{
+  x86 = 'Win32'
+  x64 = 'x64'
+}
+
+foreach ($arch in $Architecture) {
+  foreach ($config in $Configuration) {
+    $platform = $platformByArchitecture[$arch]
+    $buildDir = Join-Path $repoRoot "artifacts\build\ldk_${arch}_$config"
+    $libOutputDir = Join-Path $OutputDirectory "lib\native\$arch\$config"
+
+    New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $libOutputDir | Out-Null
+
+    $configureArgs = @(
+      '-S', $repoRoot,
+      '-B', $buildDir,
+      '-G', 'Visual Studio 17 2022',
+      '-A', $platform,
+      '-T', 'host=x64',
+      "-DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion",
+      "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=$WindowsSdkVersion",
+      '-DCMAKE_C_FLAGS=/MP',
+      '-DCMAKE_CXX_FLAGS=/MP'
+    )
+
+    Write-Host "Configuring LDK $arch $config with Windows SDK $WindowsSdkVersion"
+    & cmake @configureArgs
+    if ($LASTEXITCODE -ne 0) {
+      throw "CMake configure failed with exit code $LASTEXITCODE."
+    }
+
+    Write-Host "Building LDK $arch $config"
+    & cmake --build $buildDir --config $config --target Ldk --parallel
+    if ($LASTEXITCODE -ne 0) {
+      throw "CMake build failed with exit code $LASTEXITCODE."
+    }
+
+    $preferredLibPaths = if ($config -eq 'Debug') {
+      @(
+        Join-Path $repoRoot "lib\$arch\Debug\Ldk.lib"
+        Join-Path $buildDir "$config\Ldk.lib"
+      )
+    } else {
+      @(
+        Join-Path $repoRoot "lib\$arch\Ldk.lib"
+        Join-Path $buildDir "$config\Ldk.lib"
+      )
+    }
+
+    $ldkLib = $preferredLibPaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if ([string]::IsNullOrWhiteSpace($ldkLib)) {
+      $available = Get-ChildItem -Path $repoRoot, $buildDir -Filter 'Ldk.lib' -Recurse -File -ErrorAction SilentlyContinue |
+        ForEach-Object { $_.FullName }
+      throw "Ldk.lib was not found for $arch $config. Available libs: $($available -join ', ')"
+    }
+
+    Copy-Item -Path $ldkLib -Destination (Join-Path $libOutputDir 'Ldk.lib') -Force
+
+    $pdbCandidates = @(
+      Get-ChildItem -Path (Split-Path -Parent $ldkLib) -Filter 'Ldk.pdb' -File -ErrorAction SilentlyContinue
+    )
+    foreach ($pdb in $pdbCandidates) {
+      Copy-Item -Path $pdb.FullName -Destination (Join-Path $libOutputDir $pdb.Name) -Force
+    }
+
+    Write-Host "Staged LDK library in $libOutputDir"
+  }
+}

--- a/scripts/nuget/Get-LdkVersion.ps1
+++ b/scripts/nuget/Get-LdkVersion.ps1
@@ -1,0 +1,26 @@
+param(
+  [string] $VersionHeader
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($VersionHeader)) {
+  $VersionHeader = Join-Path $repoRoot 'include\Ldk\internal\version.h'
+}
+
+if (-not (Test-Path $VersionHeader)) {
+  throw "Version header was not found: $VersionHeader"
+}
+
+$content = Get-Content -Raw $VersionHeader
+$major = [regex]::Match($content, '#define\s+LDK_VERSION_MAJOR\s+(\d+)')
+$minor = [regex]::Match($content, '#define\s+LDK_VERSION_MINOR\s+(\d+)')
+$patch = [regex]::Match($content, '#define\s+LDK_VERSION_PATCH\s+(\d+)')
+
+if (-not ($major.Success -and $minor.Success -and $patch.Success)) {
+  throw "Could not parse LDK_VERSION_MAJOR/MINOR/PATCH from $VersionHeader"
+}
+
+"$($major.Groups[1].Value).$($minor.Groups[1].Value).$($patch.Groups[1].Value)"

--- a/scripts/nuget/Pack-LdkNuGet.ps1
+++ b/scripts/nuget/Pack-LdkNuGet.ps1
@@ -1,0 +1,53 @@
+param(
+  [string] $Version,
+  [string] $OutputDirectory,
+  [string] $NuGetExe
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+  $Version = & (Join-Path $PSScriptRoot 'Get-LdkVersion.ps1')
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+  $OutputDirectory = Join-Path $repoRoot 'artifacts\nuget'
+}
+
+$manifest = Join-Path $repoRoot 'nuget\ldk.nuspec'
+$stagingDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+foreach ($arch in @('x86', 'x64')) {
+  foreach ($config in @('Debug', 'Release')) {
+    $requiredPath = "lib\native\$arch\$config\Ldk.lib"
+    $fullPath = Join-Path $stagingDirectory $requiredPath
+    if (-not (Test-Path $fullPath)) {
+      throw "Required prebuilt library is missing: $fullPath. Run scripts\nuget\Build-LdkNuGetLibs.ps1 first."
+    }
+  }
+}
+
+Write-Host "Packing LDK $Version to $OutputDirectory"
+if ([string]::IsNullOrWhiteSpace($NuGetExe)) {
+  $nuget = Get-Command nuget -ErrorAction SilentlyContinue
+  if (-not $nuget) {
+    throw "nuget command was not found. Pass -NuGetExe or add nuget.exe to PATH."
+  }
+
+  $NuGetExe = $nuget.Source
+} else {
+  $NuGetExe = (Resolve-Path $NuGetExe).Path
+}
+
+& $NuGetExe pack $manifest `
+  -OutputDirectory $OutputDirectory `
+  -Version $Version `
+  -NonInteractive
+
+if ($LASTEXITCODE -ne 0) {
+  throw "nuget pack failed with exit code $LASTEXITCODE."
+}

--- a/scripts/nuget/Pack-LdkReleaseAssets.ps1
+++ b/scripts/nuget/Pack-LdkReleaseAssets.ps1
@@ -1,0 +1,152 @@
+param(
+  [string] $Version,
+  [string] $OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+function Compress-DirectoryWithRetry {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $SourceDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string] $DestinationPath
+  )
+
+  for ($attempt = 1; $attempt -le 5; $attempt++) {
+    try {
+      Compress-Archive -Path $SourceDirectory -DestinationPath $DestinationPath -CompressionLevel Optimal
+      return
+    } catch {
+      if ($attempt -eq 5) {
+        throw
+      }
+
+      Write-Warning "Compress-Archive failed on attempt $attempt. Retrying in 2 seconds. $($_.Exception.Message)"
+      Start-Sleep -Seconds 2
+      Remove-Item -Force -Path $DestinationPath -ErrorAction SilentlyContinue
+    }
+  }
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+  $Version = & (Join-Path $PSScriptRoot 'Get-LdkVersion.ps1')
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+  $OutputDirectory = Join-Path $repoRoot 'artifacts\release'
+}
+
+$nugetDirectory = Join-Path $repoRoot 'artifacts\nuget'
+$stagingDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
+$workDirectory = Join-Path $repoRoot 'artifacts\release-staging'
+$workDirectory = [System.IO.Path]::GetFullPath($workDirectory)
+$repoRootPrefix = $repoRoot.TrimEnd('\') + '\'
+if (-not $workDirectory.StartsWith($repoRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "Work directory must be inside the repository: $repoRoot"
+}
+
+$bundleRoot = Join-Path $workDirectory "ldk-$Version"
+$bundleCMakePackageDirectory = Join-Path $bundleRoot 'share\ldk\cmake'
+$prebuiltZipPath = Join-Path $OutputDirectory "ldk-$Version-prebuilt.zip"
+$checksumPath = Join-Path $OutputDirectory "ldk-$Version-SHA256SUMS.txt"
+$packagePath = Join-Path $nugetDirectory "ldk.$Version.nupkg"
+$releasePackagePath = Join-Path $OutputDirectory "ldk.$Version.nupkg"
+
+if (-not (Test-Path $packagePath)) {
+  throw "NuGet package was not found: $packagePath. Run scripts\nuget\Pack-LdkNuGet.ps1 first."
+}
+
+foreach ($arch in @('x86', 'x64')) {
+  foreach ($config in @('Debug', 'Release')) {
+    $requiredPath = Join-Path $stagingDirectory "lib\native\$arch\$config\Ldk.lib"
+    if (-not (Test-Path $requiredPath)) {
+      throw "Required prebuilt release asset file is missing: $requiredPath."
+    }
+  }
+}
+
+Remove-Item -Recurse -Force -Path $workDirectory -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+New-Item -ItemType Directory -Force -Path $bundleRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $bundleCMakePackageDirectory | Out-Null
+
+Copy-Item -Path (Join-Path $repoRoot 'README.md') -Destination $bundleRoot -Force
+Copy-Item -Path (Join-Path $repoRoot 'LICENSE') -Destination $bundleRoot -Force
+Copy-Item -Path (Join-Path $repoRoot 'docs') -Destination (Join-Path $bundleRoot 'docs') -Recurse -Force
+Copy-Item -Path (Join-Path $repoRoot 'include') -Destination (Join-Path $bundleRoot 'include') -Recurse -Force
+Copy-Item -Path (Join-Path $repoRoot 'cmake') -Destination (Join-Path $bundleRoot 'cmake') -Recurse -Force
+Copy-Item -Path (Join-Path $repoRoot 'cmake\*') -Destination $bundleCMakePackageDirectory -Recurse -Force
+Copy-Item -Path (Join-Path $repoRoot 'nuget\build') -Destination (Join-Path $bundleRoot 'build') -Recurse -Force
+Copy-Item -Path (Join-Path $stagingDirectory 'lib') -Destination (Join-Path $bundleRoot 'lib') -Recurse -Force
+
+$versionMajor = ($Version -split '\.')[0]
+$configCMake = @"
+get_filename_component(PACKAGE_PREFIX_DIR "`${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+set(ldk_ROOT "`${PACKAGE_PREFIX_DIR}")
+set(LDK_ROOT "`${PACKAGE_PREFIX_DIR}")
+
+include("`${CMAKE_CURRENT_LIST_DIR}/Ldk.cmake")
+"@
+Set-Content -LiteralPath (Join-Path $bundleCMakePackageDirectory 'ldk-config.cmake') -Value $configCMake -Encoding ASCII
+
+$configVersionCMake = @"
+set(PACKAGE_VERSION "$Version")
+
+if(PACKAGE_FIND_VERSION)
+  if(PACKAGE_FIND_VERSION VERSION_GREATER PACKAGE_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  elseif(NOT PACKAGE_FIND_VERSION_MAJOR EQUAL $versionMajor)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()
+"@
+Set-Content -LiteralPath (Join-Path $bundleCMakePackageDirectory 'ldk-config-version.cmake') -Value $configVersionCMake -Encoding ASCII
+
+$bundleReadme = @"
+# LDK $Version Prebuilt Release Bundle
+
+This archive is an offline-friendly prebuilt bundle built by the GitHub Actions
+Package workflow.
+
+Contents:
+
+- include/: public LDK headers
+- cmake/: CMake helpers
+- share/ldk/cmake/: CMake package config for find_package(ldk CONFIG)
+- build/native/: native MSBuild props and targets from the NuGet package
+- lib/native/: prebuilt Ldk.lib for x86 and x64, Debug and Release
+- docs/: repository documentation
+
+The prebuilt driver libraries target Visual Studio 2022 and Windows SDK/WDK
+10.0.22621.0. Validate the final driver with the Windows, WDK, SDK, Visual
+Studio, architecture, Driver Verifier, and code integrity settings that you
+ship.
+"@
+Set-Content -LiteralPath (Join-Path $bundleRoot 'README.release.md') -Value $bundleReadme -Encoding UTF8
+
+Remove-Item -Force -Path $prebuiltZipPath -ErrorAction SilentlyContinue
+Remove-Item -Force -Path $releasePackagePath -ErrorAction SilentlyContinue
+Remove-Item -Force -Path $checksumPath -ErrorAction SilentlyContinue
+
+Compress-DirectoryWithRetry -SourceDirectory $bundleRoot -DestinationPath $prebuiltZipPath
+Copy-Item -Path $packagePath -Destination $releasePackagePath -Force
+
+Get-FileHash -Algorithm SHA256 -Path $prebuiltZipPath, $releasePackagePath |
+  ForEach-Object { "$($_.Hash.ToLowerInvariant())  $([System.IO.Path]::GetFileName($_.Path))" } |
+  Set-Content -LiteralPath $checksumPath -Encoding ASCII
+
+Write-Host "Created release assets:"
+Get-ChildItem -Path $OutputDirectory -File | Sort-Object FullName | ForEach-Object {
+  Write-Host "  $($_.FullName)"
+}

--- a/scripts/nuget/Push-LdkNuGet.ps1
+++ b/scripts/nuget/Push-LdkNuGet.ps1
@@ -1,0 +1,42 @@
+param(
+  [string] $PackageDirectory,
+  [string] $Source = 'https://api.nuget.org/v3/index.json',
+  [string] $ApiKey = $env:NUGET_API_KEY,
+  [switch] $SkipDuplicate
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
+  $PackageDirectory = Join-Path $repoRoot 'artifacts\nuget'
+}
+
+if ([string]::IsNullOrWhiteSpace($ApiKey)) {
+  throw 'NUGET_API_KEY is required to publish packages.'
+}
+
+$packages = @(Get-ChildItem -Path $PackageDirectory -Filter '*.nupkg' -File | Sort-Object FullName)
+if ($packages.Count -eq 0) {
+  throw "No .nupkg files were found in $PackageDirectory"
+}
+
+foreach ($package in $packages) {
+  $arguments = @(
+    'nuget', 'push', $package.FullName,
+    '--source', $Source,
+    '--api-key', $ApiKey,
+    '--no-symbols'
+  )
+
+  if ($SkipDuplicate) {
+    $arguments += '--skip-duplicate'
+  }
+
+  Write-Host "Publishing $($package.Name) to $Source"
+  & dotnet @arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "dotnet nuget push failed with exit code $LASTEXITCODE."
+  }
+}

--- a/scripts/nuget/Test-LdkNuGetPackage.ps1
+++ b/scripts/nuget/Test-LdkNuGetPackage.ps1
@@ -1,0 +1,199 @@
+param(
+  [string] $PackageDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [string] $Version,
+
+  [ValidateSet('x86', 'x64')]
+  [string] $Architecture = 'x64',
+
+  [ValidateSet('Debug', 'Release')]
+  [string] $Configuration = 'Release',
+
+  [string] $WindowsSdkVersion = '10.0.22621.0',
+
+  [string] $WorkDirectory,
+
+  [string] $NuGetExe,
+
+  [switch] $SkipDriverBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
+  $PackageDirectory = Join-Path $repoRoot 'artifacts\nuget'
+}
+
+if ([string]::IsNullOrWhiteSpace($WorkDirectory)) {
+  $WorkDirectory = Join-Path $repoRoot "artifacts\nuget-consumer-test\$Architecture\$Configuration"
+}
+
+$WorkDirectory = [System.IO.Path]::GetFullPath($WorkDirectory)
+$repoRootPrefix = $repoRoot.TrimEnd('\') + '\'
+if (-not $WorkDirectory.StartsWith($repoRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "WorkDirectory must be inside the repository: $repoRoot"
+}
+
+$PackageDirectory = (Resolve-Path $PackageDirectory).Path
+$packagePath = Join-Path $PackageDirectory "ldk.$Version.nupkg"
+if (-not (Test-Path $packagePath)) {
+  throw "NuGet package was not found: $packagePath"
+}
+
+if ([string]::IsNullOrWhiteSpace($NuGetExe)) {
+  $nuget = Get-Command nuget -ErrorAction SilentlyContinue
+  if (-not $nuget) {
+    throw "nuget command was not found. Pass -NuGetExe or add nuget.exe to PATH."
+  }
+
+  $NuGetExe = $nuget.Source
+} else {
+  $NuGetExe = (Resolve-Path $NuGetExe).Path
+}
+
+$platformByArchitecture = @{
+  x86 = 'Win32'
+  x64 = 'x64'
+}
+$platform = $platformByArchitecture[$Architecture]
+
+Remove-Item -Recurse -Force -Path $WorkDirectory -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+
+$packagesDirectory = Join-Path $WorkDirectory 'packages'
+& $NuGetExe install ldk `
+  -Version $Version `
+  -Source $PackageDirectory `
+  -OutputDirectory $packagesDirectory `
+  -NonInteractive `
+  -Verbosity detailed
+
+if ($LASTEXITCODE -ne 0) {
+  throw "nuget install failed with exit code $LASTEXITCODE."
+}
+
+$packageRoot = Join-Path $packagesDirectory "ldk.$Version"
+if (-not (Test-Path $packageRoot)) {
+  $installedPackageCandidates = @(
+    Get-ChildItem -Path $packagesDirectory -Directory |
+      Where-Object { $_.Name -like 'ldk.*' } |
+      Sort-Object Name
+  )
+
+  if ($installedPackageCandidates.Count -ne 1) {
+    throw "Expected exactly one installed ldk package under '$packagesDirectory', found $($installedPackageCandidates.Count)."
+  }
+
+  $packageRoot = $installedPackageCandidates[0].FullName
+}
+
+$packageRoot = (Resolve-Path $packageRoot).Path
+
+$requiredPackagePaths = @(
+  'README.md',
+  'build\native\ldk.props',
+  'build\native\ldk.targets',
+  'cmake\Ldk.cmake',
+  'include\Ldk\Windows.h',
+  "lib\native\$Architecture\$Configuration\Ldk.lib"
+)
+
+foreach ($requiredPath in $requiredPackagePaths) {
+  $fullPath = Join-Path $packageRoot $requiredPath
+  if (-not (Test-Path $fullPath)) {
+    throw "Installed package is missing expected file: $fullPath"
+  }
+}
+
+$packageReadme = Get-Content -LiteralPath (Join-Path $packageRoot 'README.md') -Raw -Encoding UTF8
+if ($packageReadme -notmatch 'LDK NuGet Package') {
+  throw "Installed package README.md does not look like the NuGet package README."
+}
+
+if ($SkipDriverBuild) {
+  Write-Host "NuGet package layout test passed for $Architecture ${Configuration}: $packageRoot"
+  return
+}
+
+$consumerDirectory = Join-Path $WorkDirectory 'consumer'
+New-Item -ItemType Directory -Force -Path $consumerDirectory | Out-Null
+
+$cmakePackageRoot = $packageRoot.Replace('\', '/')
+$cmakeLists = @"
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(ldk_nuget_package_smoke LANGUAGES C)
+
+set(LDK_ROOT "$cmakePackageRoot")
+include("$cmakePackageRoot/cmake/Ldk.cmake")
+
+ldk_add_driver(ldk_nuget_package_smoke main.c)
+"@
+Set-Content -LiteralPath (Join-Path $consumerDirectory 'CMakeLists.txt') -Value $cmakeLists -Encoding UTF8
+
+$mainC = @'
+#include <Ldk/Windows.h>
+
+DRIVER_UNLOAD DriverUnload;
+
+VOID
+DriverUnload(
+    _In_ PDRIVER_OBJECT DriverObject
+    )
+{
+    UNREFERENCED_PARAMETER(DriverObject);
+}
+
+NTSTATUS
+DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+    )
+{
+    CRITICAL_SECTION CriticalSection;
+
+    UNREFERENCED_PARAMETER(RegistryPath);
+
+    InitializeCriticalSection(&CriticalSection);
+    DeleteCriticalSection(&CriticalSection);
+
+    DriverObject->DriverUnload = DriverUnload;
+    return STATUS_SUCCESS;
+}
+'@
+Set-Content -LiteralPath (Join-Path $consumerDirectory 'main.c') -Value $mainC -Encoding UTF8
+
+$buildDirectory = Join-Path $WorkDirectory "build_$Architecture"
+$configureArgs = @(
+  '-S', $consumerDirectory,
+  '-B', $buildDirectory,
+  '-G', 'Visual Studio 17 2022',
+  '-A', $platform,
+  '-T', 'host=x64',
+  "-DLDK_WDK_VERSION=$WindowsSdkVersion",
+  "-DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion",
+  "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=$WindowsSdkVersion"
+)
+
+Write-Host "Configuring NuGet package consumer for $Architecture $Configuration"
+& cmake @configureArgs
+if ($LASTEXITCODE -ne 0) {
+  throw "CMake configure failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Building NuGet package consumer for $Architecture $Configuration"
+& cmake --build $buildDirectory --config $Configuration --target ldk_nuget_package_smoke --parallel
+if ($LASTEXITCODE -ne 0) {
+  throw "CMake build failed with exit code $LASTEXITCODE."
+}
+
+$driverPath = Join-Path $buildDirectory "$Configuration\ldk_nuget_package_smoke.sys"
+if (-not (Test-Path $driverPath)) {
+  throw "NuGet package consumer driver was not produced: $driverPath"
+}
+
+Write-Host "NuGet package consumer test passed: $driverPath"

--- a/scripts/nuget/Test-LdkReleaseAssets.ps1
+++ b/scripts/nuget/Test-LdkReleaseAssets.ps1
@@ -1,0 +1,161 @@
+param(
+  [string] $ReleaseDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [string] $Version,
+
+  [ValidateSet('x86', 'x64')]
+  [string] $Architecture = 'x64',
+
+  [ValidateSet('Debug', 'Release')]
+  [string] $Configuration = 'Release',
+
+  [string] $WindowsSdkVersion = '10.0.22621.0',
+
+  [string] $WorkDirectory,
+
+  [switch] $SkipDriverBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+if ([string]::IsNullOrWhiteSpace($ReleaseDirectory)) {
+  $ReleaseDirectory = Join-Path $repoRoot 'artifacts\release'
+}
+
+if ([string]::IsNullOrWhiteSpace($WorkDirectory)) {
+  $WorkDirectory = Join-Path $repoRoot "artifacts\release-consumer-test\$Architecture\$Configuration"
+}
+
+$WorkDirectory = [System.IO.Path]::GetFullPath($WorkDirectory)
+$repoRootPrefix = $repoRoot.TrimEnd('\') + '\'
+if (-not $WorkDirectory.StartsWith($repoRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "WorkDirectory must be inside the repository: $repoRoot"
+}
+
+$ReleaseDirectory = (Resolve-Path $ReleaseDirectory).Path
+$prebuiltZipPath = Join-Path $ReleaseDirectory "ldk-$Version-prebuilt.zip"
+if (-not (Test-Path $prebuiltZipPath)) {
+  throw "Prebuilt release zip was not found: $prebuiltZipPath"
+}
+
+$platformByArchitecture = @{
+  x86 = 'Win32'
+  x64 = 'x64'
+}
+$platform = $platformByArchitecture[$Architecture]
+
+Remove-Item -Recurse -Force -Path $WorkDirectory -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+
+$unpackDirectory = Join-Path $WorkDirectory 'prebuilt'
+Expand-Archive -Path $prebuiltZipPath -DestinationPath $unpackDirectory -Force
+
+$bundleRoot = Join-Path $unpackDirectory "ldk-$Version"
+if (-not (Test-Path (Join-Path $bundleRoot 'cmake\Ldk.cmake'))) {
+  if (Test-Path (Join-Path $unpackDirectory 'cmake\Ldk.cmake')) {
+    $bundleRoot = $unpackDirectory
+  } else {
+    $bundleRoot = Get-ChildItem -Path $unpackDirectory -Directory |
+      Where-Object { Test-Path (Join-Path $_.FullName 'cmake\Ldk.cmake') } |
+      Select-Object -First 1 -ExpandProperty FullName
+  }
+}
+
+if ([string]::IsNullOrWhiteSpace($bundleRoot) -or -not (Test-Path (Join-Path $bundleRoot 'cmake\Ldk.cmake'))) {
+  throw "Unpacked prebuilt release bundle does not contain cmake\Ldk.cmake."
+}
+
+foreach ($requiredPath in @(
+  "lib\native\$Architecture\$Configuration\Ldk.lib",
+  'share\ldk\cmake\ldk-config.cmake',
+  'share\ldk\cmake\ldk-config-version.cmake',
+  'share\ldk\cmake\Ldk.cmake',
+  'include\Ldk\Windows.h'
+)) {
+  $fullPath = Join-Path $bundleRoot $requiredPath
+  if (-not (Test-Path $fullPath)) {
+    throw "Prebuilt release bundle is missing expected file: $fullPath"
+  }
+}
+
+if ($SkipDriverBuild) {
+  Write-Host "Prebuilt release layout test passed for $Architecture ${Configuration}: $bundleRoot"
+  return
+}
+
+$consumerDirectory = Join-Path $WorkDirectory 'consumer'
+New-Item -ItemType Directory -Force -Path $consumerDirectory | Out-Null
+
+$cmakeBundleRoot = $bundleRoot.Replace('\', '/')
+$cmakeLists = @"
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(ldk_release_asset_smoke LANGUAGES C)
+
+find_package(ldk CONFIG REQUIRED PATHS "$cmakeBundleRoot" NO_DEFAULT_PATH)
+
+ldk_add_driver(ldk_release_asset_smoke main.c)
+"@
+Set-Content -LiteralPath (Join-Path $consumerDirectory 'CMakeLists.txt') -Value $cmakeLists -Encoding UTF8
+
+$mainC = @'
+#include <Ldk/Windows.h>
+
+DRIVER_UNLOAD DriverUnload;
+
+VOID
+DriverUnload(
+    _In_ PDRIVER_OBJECT DriverObject
+    )
+{
+    UNREFERENCED_PARAMETER(DriverObject);
+}
+
+NTSTATUS
+DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+    )
+{
+    UNREFERENCED_PARAMETER(RegistryPath);
+
+    DriverObject->DriverUnload = DriverUnload;
+    return STATUS_SUCCESS;
+}
+'@
+Set-Content -LiteralPath (Join-Path $consumerDirectory 'main.c') -Value $mainC -Encoding UTF8
+
+$buildDirectory = Join-Path $WorkDirectory "build_$Architecture"
+$configureArgs = @(
+  '-S', $consumerDirectory,
+  '-B', $buildDirectory,
+  '-G', 'Visual Studio 17 2022',
+  '-A', $platform,
+  '-T', 'host=x64',
+  "-DLDK_WDK_VERSION=$WindowsSdkVersion",
+  "-DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion",
+  "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=$WindowsSdkVersion"
+)
+
+Write-Host "Configuring prebuilt release asset consumer for $Architecture $Configuration"
+& cmake @configureArgs
+if ($LASTEXITCODE -ne 0) {
+  throw "CMake configure failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Building prebuilt release asset consumer for $Architecture $Configuration"
+& cmake --build $buildDirectory --config $Configuration --target ldk_release_asset_smoke --parallel
+if ($LASTEXITCODE -ne 0) {
+  throw "CMake build failed with exit code $LASTEXITCODE."
+}
+
+$driverPath = Join-Path $buildDirectory "$Configuration\ldk_release_asset_smoke.sys"
+if (-not (Test-Path $driverPath)) {
+  throw "Prebuilt release asset consumer driver was not produced: $driverPath"
+}
+
+Write-Host "Prebuilt release asset consumer test passed: $driverPath"

--- a/scripts/release/Prepare-LdkRelease.ps1
+++ b/scripts/release/Prepare-LdkRelease.ps1
@@ -1,0 +1,157 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^\d+\.\d+\.\d+$')]
+  [string] $Version,
+
+  [string] $Branch = 'main',
+
+  [switch] $Push,
+
+  [switch] $AllowNonMainBranch
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$versionHeader = Join-Path $repoRoot 'include\Ldk\internal\version.h'
+$tagName = "v$Version"
+$gitExe = (Get-Command git.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)
+
+if ([string]::IsNullOrWhiteSpace($gitExe)) {
+  throw "git.exe was not found in PATH."
+}
+
+function Invoke-Git {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]] $Arguments
+  )
+
+  Write-Host "[git] $($Arguments -join ' ')"
+  & $gitExe @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+  }
+}
+
+function Test-GitRefExists {
+  param([string] $Ref)
+
+  & $gitExe rev-parse --verify --quiet -- $Ref *> $null
+  return $LASTEXITCODE -eq 0
+}
+
+function Ensure-TrimmedString {
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowNull()]
+    [object] $Value,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Name
+  )
+
+  if ($null -eq $Value) {
+    throw "$Name was empty."
+  }
+
+  if ($Value -is [string]) {
+    return $Value.Trim()
+  }
+
+  return "${Value}".Trim()
+}
+
+Push-Location $repoRoot
+try {
+  Invoke-Git @('rev-parse', '--show-toplevel') *> $null
+
+  $currentBranch = Ensure-TrimmedString -Value (Invoke-Git @('branch', '--show-current')) -Name 'Current branch'
+  if (-not $AllowNonMainBranch -and $currentBranch -ne $Branch) {
+    throw "Release preparation must run on '$Branch'. Current branch is '$currentBranch'."
+  }
+
+  Invoke-Git @('fetch', 'origin', $Branch, '--tags')
+  if (-not $AllowNonMainBranch) {
+    $localHead = Ensure-TrimmedString -Value (Invoke-Git @('rev-parse', 'HEAD')) -Name 'Local HEAD'
+    $remoteHead = Ensure-TrimmedString -Value (Invoke-Git @('rev-parse', "origin/$Branch")) -Name 'Remote HEAD'
+    if ($localHead -ne $remoteHead) {
+      throw "Local '$Branch' must match origin/$Branch before preparing a release."
+    }
+  }
+
+  $status = (Invoke-Git @('status', '--porcelain'))
+  if ($null -ne $status -and -not [string]::IsNullOrWhiteSpace(($status -join "`n"))) {
+    throw "Working tree must be clean before preparing a release."
+  }
+
+  if (Test-GitRefExists "refs/tags/$tagName") {
+    throw "Local tag already exists: $tagName"
+  }
+
+  & $gitExe ls-remote --exit-code --tags origin -- $tagName *> $null
+  if ($LASTEXITCODE -eq 0) {
+    throw "Remote tag already exists on origin: $tagName"
+  }
+  if ($LASTEXITCODE -ne 2) {
+    throw "Could not check whether remote tag exists on origin: $tagName"
+  }
+
+  $parts = $Version.Split('.')
+  $major = $parts[0]
+  $minor = $parts[1]
+  $patch = $parts[2]
+
+  if (-not (Test-Path $versionHeader)) {
+    throw "Version header was not found: $versionHeader"
+  }
+
+  $currentVersion = Ensure-TrimmedString -Value (& (Join-Path $repoRoot 'scripts\nuget\Get-LdkVersion.ps1')) -Name 'Current version'
+  if ($currentVersion -eq $Version) {
+    throw "Version header is already $Version."
+  }
+
+  $content = Get-Content -LiteralPath $versionHeader -Raw
+  $content = [regex]::Replace(
+    $content,
+    '(?m)^(#define\s+LDK_VERSION_MAJOR\s+)\d+(\s*)$',
+    { param($match) "$($match.Groups[1].Value)$major$($match.Groups[2].Value)" })
+  $content = [regex]::Replace(
+    $content,
+    '(?m)^(#define\s+LDK_VERSION_MINOR\s+)\d+(\s*)$',
+    { param($match) "$($match.Groups[1].Value)$minor$($match.Groups[2].Value)" })
+  $content = [regex]::Replace(
+    $content,
+    '(?m)^(#define\s+LDK_VERSION_PATCH\s+)\d+(\s*)$',
+    { param($match) "$($match.Groups[1].Value)$patch$($match.Groups[2].Value)" })
+
+  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($versionHeader, $content, $utf8NoBom)
+
+  $resolvedVersion = Ensure-TrimmedString -Value (& (Join-Path $repoRoot 'scripts\nuget\Get-LdkVersion.ps1')) -Name 'Resolved version'
+  if ($resolvedVersion -ne $Version) {
+    throw "Version header update failed. Expected $Version, got $resolvedVersion."
+  }
+
+  Invoke-Git @('diff', '--check')
+  Invoke-Git @('add', '--', 'include/Ldk/internal/version.h')
+  Invoke-Git @('commit', '-m', "release LDK $Version")
+  Invoke-Git @('tag', '-a', $tagName, '-m', "LDK $Version")
+
+  if ($Push) {
+    Invoke-Git @('push', 'origin', $currentBranch)
+    Invoke-Git @('push', 'origin', $tagName)
+    Write-Host "Pushed $currentBranch and $tagName. The Package workflow should start from the tag."
+  } else {
+    Write-Host "Prepared release commit and tag locally."
+    Write-Host "Push with:"
+    Write-Host "  git push origin $currentBranch"
+    Write-Host "  git push origin $tagName"
+  }
+} catch {
+  Write-Error $_
+  exit 1
+} finally {
+  Pop-Location
+}

--- a/src/kernel32/consoleapi.c
+++ b/src/kernel32/consoleapi.c
@@ -1,7 +1,16 @@
 ﻿#include "winbase.h"
 #include "../peb.h"
 
+BOOL
+LdkpReadConsole (
+    _In_ HANDLE hConsoleInput,
+    _Out_writes_bytes_(nNumberOfBytesToRead) LPVOID lpBuffer,
+    _In_ DWORD nNumberOfBytesToRead,
+    _Out_ LPDWORD lpNumberOfBytesRead
+    );
+
 #ifdef ALLOC_PRAGMA
+#pragma alloc_text(PAGE, LdkpReadConsole)
 #pragma alloc_text(PAGE, ReadConsoleA)
 #pragma alloc_text(PAGE, ReadConsoleW)
 #pragma alloc_text(PAGE, WriteConsoleA)
@@ -86,8 +95,13 @@ GetConsoleMode (
     _Out_ LPDWORD lpMode
     )
 {
-    if (LdkGetConsoleHandle( hConsoleHandle,
-                             &hConsoleHandle )) {
+    if (! ARGUMENT_PRESENT(lpMode)) {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return FALSE;
+    }
+
+    if (! LdkGetConsoleHandle( hConsoleHandle,
+                               &hConsoleHandle )) {
         SetLastError( ERROR_INVALID_HANDLE );
         return FALSE;
     }
@@ -113,8 +127,8 @@ SetConsoleMode (
     _In_ DWORD dwMode
     )
 {
-    if (LdkGetConsoleHandle( hConsoleHandle,
-                             &hConsoleHandle )) {
+    if (! LdkGetConsoleHandle( hConsoleHandle,
+                               &hConsoleHandle )) {
         SetLastError( ERROR_INVALID_HANDLE );
         return FALSE;
     }
@@ -133,41 +147,14 @@ SetConsoleMode (
 }
 
 
-WINBASEAPI
-_Success_(return != FALSE)
 BOOL
-WINAPI
-ReadConsoleA (
+LdkpReadConsole (
     _In_ HANDLE hConsoleInput,
-    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(TCHAR%),*lpNumberOfCharsRead * sizeof(TCHAR%)) LPVOID lpBuffer,
-    _In_ DWORD nNumberOfCharsToRead,
-    _Out_ _Deref_out_range_(<=,nNumberOfCharsToRead) LPDWORD lpNumberOfCharsRead,
-    _In_opt_ PCONSOLE_READCONSOLE_CONTROL pInputControl
+    _Out_writes_bytes_(nNumberOfBytesToRead) LPVOID lpBuffer,
+    _In_ DWORD nNumberOfBytesToRead,
+    _Out_ LPDWORD lpNumberOfBytesRead
     )
 {
-    PAGED_CODE();
-
-    return ReadConsoleW( hConsoleInput,
-                         lpBuffer,
-                         nNumberOfCharsToRead,
-                         lpNumberOfCharsRead,
-                         pInputControl );
-}
-
-WINBASEAPI
-_Success_(return != FALSE)
-BOOL
-WINAPI
-ReadConsoleW (
-    _In_ HANDLE hConsoleInput,
-    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(TCHAR%),*lpNumberOfCharsRead * sizeof(TCHAR%)) LPVOID lpBuffer,
-    _In_ DWORD nNumberOfCharsToRead,
-    _Out_ _Deref_out_range_(<=,nNumberOfCharsToRead) LPDWORD lpNumberOfCharsRead,
-    _In_opt_ PCONSOLE_READCONSOLE_CONTROL pInputControl
-    )
-{
-    UNREFERENCED_PARAMETER( pInputControl );
-
     PAGED_CODE();
 
     if (! LdkGetConsoleHandle( hConsoleInput,
@@ -179,8 +166,6 @@ ReadConsoleW (
         return FALSE;
     }
 
-    KdBreakPoint();
-
     NTSTATUS Status;
     IO_STATUS_BLOCK ioStatus;
 
@@ -190,7 +175,7 @@ ReadConsoleW (
                          NULL,
                          &ioStatus,
                          lpBuffer,
-                         nNumberOfCharsToRead * sizeof(WCHAR),
+                         nNumberOfBytesToRead,
                          NULL,
                          NULL );
 
@@ -202,19 +187,75 @@ ReadConsoleW (
             Status = ioStatus.Status;
         }
     }
-	if (NT_SUCCESS(Status)) {
-        *lpNumberOfCharsRead = (DWORD)ioStatus.Information / sizeof(WCHAR);
+    if (NT_SUCCESS(Status)) {
+        *lpNumberOfBytesRead = (DWORD)ioStatus.Information;
         return TRUE;
     } else if (Status == STATUS_END_OF_FILE) {
-        *lpNumberOfCharsRead = 0;
+        *lpNumberOfBytesRead = 0;
         return TRUE;
     } else {
         if (NT_WARNING(Status)) {
-            *lpNumberOfCharsRead = (DWORD)ioStatus.Information;
+            *lpNumberOfBytesRead = (DWORD)ioStatus.Information;
         }
     }
     LdkSetLastNTError( Status );
     return FALSE;
+}
+
+
+WINBASEAPI
+_Success_(return != FALSE)
+BOOL
+WINAPI
+ReadConsoleA (
+    _In_ HANDLE hConsoleInput,
+    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(CHAR),*lpNumberOfCharsRead * sizeof(CHAR)) LPVOID lpBuffer,
+    _In_ DWORD nNumberOfCharsToRead,
+    _Out_ _Deref_out_range_(<=,nNumberOfCharsToRead) LPDWORD lpNumberOfCharsRead,
+    _In_opt_ PCONSOLE_READCONSOLE_CONTROL pInputControl
+    )
+{
+    UNREFERENCED_PARAMETER( pInputControl );
+
+    PAGED_CODE();
+
+    DWORD NumberOfBytesRead = 0;
+    BOOL Result = LdkpReadConsole( hConsoleInput,
+                                   lpBuffer,
+                                   nNumberOfCharsToRead * sizeof(CHAR),
+                                   &NumberOfBytesRead );
+    *lpNumberOfCharsRead = NumberOfBytesRead / sizeof(CHAR);
+    return Result;
+}
+
+WINBASEAPI
+_Success_(return != FALSE)
+BOOL
+WINAPI
+ReadConsoleW (
+    _In_ HANDLE hConsoleInput,
+    _Out_writes_bytes_to_(nNumberOfCharsToRead * sizeof(WCHAR),*lpNumberOfCharsRead * sizeof(WCHAR)) LPVOID lpBuffer,
+    _In_ DWORD nNumberOfCharsToRead,
+    _Out_ _Deref_out_range_(<=,nNumberOfCharsToRead) LPDWORD lpNumberOfCharsRead,
+    _In_opt_ PCONSOLE_READCONSOLE_CONTROL pInputControl
+    )
+{
+    UNREFERENCED_PARAMETER( pInputControl );
+
+    PAGED_CODE();
+
+    if (nNumberOfCharsToRead > ((DWORD)-1) / sizeof(WCHAR)) {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return FALSE;
+    }
+
+    DWORD NumberOfBytesRead = 0;
+    BOOL Result = LdkpReadConsole( hConsoleInput,
+                                   lpBuffer,
+                                   nNumberOfCharsToRead * sizeof(WCHAR),
+                                   &NumberOfBytesRead );
+    *lpNumberOfCharsRead = NumberOfBytesRead / sizeof(WCHAR);
+    return Result;
 }
 
 WINBASEAPI

--- a/src/kernel32/kernel32.c
+++ b/src/kernel32/kernel32.c
@@ -366,6 +366,18 @@ LDK_FUNCTION_REGISTRATION LdkpKernel32FunctionRegistration[] = {
 		"Sleep",
 		Sleep
 	},
+    {
+        "WaitOnAddress",
+        WaitOnAddress
+    },
+    {
+        "WakeByAddressSingle",
+        WakeByAddressSingle
+    },
+    {
+        "WakeByAddressAll",
+        WakeByAddressAll
+    },
 
 	//
 	// fiberapi.c

--- a/src/kernel32/processthreadsapi.c
+++ b/src/kernel32/processthreadsapi.c
@@ -40,7 +40,14 @@ typedef struct _LDK_THREAD_CONTEXT {
 	SIZE_T dwStackSize;
 	PTHREAD_START_ROUTINE ThreadStartRoutine;
 	LPVOID lpThreadParameter;
+	DWORD ExitCode;
 } LDK_THREAD_CONTEXT, *PLDK_THREAD_CONTEXT;
+
+typedef struct _LDK_THREAD_CALLOUT_CONTEXT {
+	PTHREAD_START_ROUTINE ThreadStartRoutine;
+	LPVOID lpThreadParameter;
+	DWORD ExitCode;
+} LDK_THREAD_CALLOUT_CONTEXT, *PLDK_THREAD_CALLOUT_CONTEXT;
 
 PAGED_LOOKASIDE_LIST LdkpThreadContextLookaside;
 
@@ -85,7 +92,7 @@ _Function_class_(EXPAND_STACK_CALLOUT)
 VOID
 NTAPI
 LdkpThreadStartExpandStackAndCallout (
-    _In_ PLDK_THREAD_CONTEXT Context
+    _In_ PLDK_THREAD_CALLOUT_CONTEXT Context
     )
 {
 	PAGED_CODE();
@@ -93,10 +100,7 @@ LdkpThreadStartExpandStackAndCallout (
 	LPVOID lpThreadParameter = Context->lpThreadParameter;
 	PTHREAD_START_ROUTINE ThreadStartRoutine = Context->ThreadStartRoutine;
 
-	ExFreeToPagedLookasideList( &LdkpThreadContextLookaside,
-								Context );
-
-	ThreadStartRoutine( lpThreadParameter );
+	Context->ExitCode = ThreadStartRoutine( lpThreadParameter );
 
 	LdkpInvokeFlsCallback( NtCurrentTeb() );
 }
@@ -108,6 +112,10 @@ LdkpThreadStartRoutine (
     _In_ PLDK_THREAD_CONTEXT Context
     )
 {
+	LPVOID lpThreadParameter;
+	PTHREAD_START_ROUTINE ThreadStartRoutine;
+	SIZE_T dwStackSize;
+
 	PAGED_CODE();
 
 	if (FlagOn(Context->dwCreationFlags, CREATE_SUSPENDED)) {
@@ -115,23 +123,37 @@ LdkpThreadStartRoutine (
 		KdBreakPoint();
 	}
 
-	if (Context->dwStackSize > IoGetRemainingStackSize()) {
+	lpThreadParameter = Context->lpThreadParameter;
+	ThreadStartRoutine = Context->ThreadStartRoutine;
+	dwStackSize = Context->dwStackSize;
+
+	if (dwStackSize > IoGetRemainingStackSize()) {
+		LDK_THREAD_CALLOUT_CONTEXT CalloutContext;
+
+		CalloutContext.ThreadStartRoutine = ThreadStartRoutine;
+		CalloutContext.lpThreadParameter = lpThreadParameter;
+		CalloutContext.ExitCode = 0;
+
+		ExFreeToPagedLookasideList( &LdkpThreadContextLookaside,
+									Context );
+
 		if (NT_SUCCESS(KeExpandKernelStackAndCallout( LdkpThreadStartExpandStackAndCallout,
-													  Context,
-													  Context->dwStackSize ))) {
+													  &CalloutContext,
+													  dwStackSize ))) {
+			DWORD ExitCode = CalloutContext.ExitCode;
+			PsTerminateSystemThread( (NTSTATUS)ExitCode );
 			return;
 		}
+	} else {
+		ExFreeToPagedLookasideList( &LdkpThreadContextLookaside,
+									Context );
 	}
 
-	LPVOID lpThreadParameter = Context->lpThreadParameter;
-	PTHREAD_START_ROUTINE ThreadStartRoutine = Context->ThreadStartRoutine;
-
-	ExFreeToPagedLookasideList( &LdkpThreadContextLookaside,
-								Context );
-
-	ThreadStartRoutine( lpThreadParameter );
+	DWORD ExitCode = ThreadStartRoutine( lpThreadParameter );
 
 	LdkpInvokeFlsCallback( NtCurrentTeb() );
+
+	PsTerminateSystemThread( (NTSTATUS)ExitCode );
 }
 
 WINBASEAPI
@@ -178,6 +200,7 @@ CreateThread (
 	Context->dwStackSize = dwStackSize;
 	Context->ThreadStartRoutine = lpStartAddress;
 	Context->lpThreadParameter = lpParameter;
+	Context->ExitCode = 0;
 
 	HANDLE ThreadHandle;
 	CLIENT_ID ClientId;

--- a/src/kernel32/synchapi.c
+++ b/src/kernel32/synchapi.c
@@ -40,6 +40,9 @@
 #pragma alloc_text(PAGE, WaitForMultipleObjectsEx)
 #pragma alloc_text(PAGE, Sleep)
 #pragma alloc_text(PAGE, SleepEx)
+#pragma alloc_text(PAGE, WaitOnAddress)
+#pragma alloc_text(PAGE, WakeByAddressSingle)
+#pragma alloc_text(PAGE, WakeByAddressAll)
 #endif
 
 
@@ -777,6 +780,62 @@ Sleep (
 
 	SleepEx( dwMilliseconds,
              FALSE );
+}
+
+WINBASEAPI
+BOOL
+WINAPI
+WaitOnAddress (
+    _In_reads_bytes_(AddressSize) volatile VOID* Address,
+    _In_reads_bytes_(AddressSize) PVOID CompareAddress,
+    _In_ SIZE_T AddressSize,
+    _In_opt_ DWORD dwMilliseconds
+    )
+{
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    Status = RtlWaitOnAddress( Address,
+                               CompareAddress,
+                               AddressSize,
+                               LdkFormatTimeout( &Timeout,
+                                                 dwMilliseconds ) );
+    if (Status == STATUS_TIMEOUT) {
+        LdkSetLastNTError( Status );
+        return FALSE;
+    }
+
+    if (NT_SUCCESS(Status)) {
+        return TRUE;
+    }
+    LdkSetLastNTError( Status );
+    return FALSE;
+}
+
+WINBASEAPI
+VOID
+WINAPI
+WakeByAddressSingle (
+    _In_ PVOID Address
+    )
+{
+    PAGED_CODE();
+
+    RtlWakeAddressSingle( Address );
+}
+
+WINBASEAPI
+VOID
+WINAPI
+WakeByAddressAll (
+    _In_ PVOID Address
+    )
+{
+    PAGED_CODE();
+
+    RtlWakeAddressAll( Address );
 }
 
 WINBASEAPI

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@ LdkDriverEntry (
     Status = DriverEntry( DriverObject,
                           RegistryPath );
     if (! NT_SUCCESS(Status)) {
+        LdkTerminate();
         return Status;
     }
 

--- a/src/ntdll/alert.c
+++ b/src/ntdll/alert.c
@@ -1,0 +1,528 @@
+#include "ntdll.h"
+
+
+
+#define LDK_ALERT_BY_THREAD_ID_WAKE_BATCH 64
+#define TAG_ALERT_BY_THREAD_ID_PENDING 'tAdL'
+
+typedef struct _LDK_ALERT_BY_THREAD_ID_ENTRY {
+    LIST_ENTRY Links;
+    PETHREAD Thread;
+    PKEVENT Event;
+    BOOLEAN InList;
+    BOOLEAN Woken;
+} LDK_ALERT_BY_THREAD_ID_ENTRY, *PLDK_ALERT_BY_THREAD_ID_ENTRY;
+
+typedef struct _LDK_ALERT_BY_THREAD_ID_PENDING_ENTRY {
+    LIST_ENTRY Links;
+    PETHREAD Thread;
+} LDK_ALERT_BY_THREAD_ID_PENDING_ENTRY, *PLDK_ALERT_BY_THREAD_ID_PENDING_ENTRY;
+
+EX_SPIN_LOCK LdkpAlertByThreadIdListLock;
+LIST_ENTRY LdkpAlertByThreadIdListHead;
+LIST_ENTRY LdkpAlertByThreadIdPendingListHead;
+KEVENT LdkpAlertByThreadIdDrainedEvent;
+NPAGED_LOOKASIDE_LIST LdkpAlertByThreadIdPendingLookaside;
+LONG LdkpAlertByThreadIdWaitCount;
+BOOLEAN LdkpAlertByThreadIdShuttingDown;
+
+
+
+NTSTATUS
+LdkpInitializeAlertByThreadIdList (
+    VOID
+    );
+
+VOID
+LdkpTerminateAlertByThreadIdList(
+    VOID
+    );
+
+VOID
+LdkpReferenceAlertByThreadIdWait (
+    VOID
+    );
+
+VOID
+LdkpDereferenceAlertByThreadIdWait (
+    VOID
+    );
+
+VOID
+LdkpWakeAllAlertByThreadIdWaiters (
+    VOID
+    );
+
+PKEVENT
+LdkpRemoveAlertByThreadIdWaiterLocked (
+    _In_ PETHREAD Thread
+    );
+
+BOOLEAN
+LdkpHasPendingAlertByThreadIdLocked (
+    _In_ PETHREAD Thread
+    );
+
+BOOLEAN
+LdkpRemovePendingAlertByThreadIdLocked (
+    _In_ PETHREAD Thread
+    );
+
+VOID
+LdkpClearPendingAlertByThreadIdList (
+    VOID
+    );
+
+
+
+#ifdef ALLOC_PRAGMA
+#pragma alloc_text(INIT, LdkpInitializeAlertByThreadIdList)
+#pragma alloc_text(PAGE, LdkpTerminateAlertByThreadIdList)
+#pragma alloc_text(PAGE, LdkpWakeAllAlertByThreadIdWaiters)
+#pragma alloc_text(PAGE, LdkpClearPendingAlertByThreadIdList)
+#pragma alloc_text(PAGE, NtAlertThreadByThreadId)
+#pragma alloc_text(PAGE, NtWaitForAlertByThreadId)
+#endif
+
+
+
+ULONG
+LdkpCollectAlertByThreadIdEvents (
+    _Out_writes_(EventCount) PKEVENT* Events,
+    _In_ ULONG EventCount
+    )
+{
+    ULONG Count = 0;
+    PLIST_ENTRY Current;
+    KIRQL OldIrql;
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+    Current = LdkpAlertByThreadIdListHead.Flink;
+    while (Current != &LdkpAlertByThreadIdListHead && Count < EventCount) {
+        PLDK_ALERT_BY_THREAD_ID_ENTRY Entry;
+        PLIST_ENTRY Next;
+
+        Next = Current->Flink;
+        Entry = CONTAINING_RECORD( Current,
+                                   LDK_ALERT_BY_THREAD_ID_ENTRY,
+                                   Links );
+        Entry->InList = FALSE;
+        Entry->Woken = TRUE;
+        RemoveEntryList( &Entry->Links );
+        Events[Count++] = Entry->Event;
+
+        Current = Next;
+    }
+    ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                OldIrql );
+
+    return Count;
+}
+
+VOID
+LdkpSetAlertByThreadIdEvents (
+    _In_reads_(EventCount) PKEVENT* Events,
+    _In_ ULONG EventCount
+    )
+{
+    ULONG Index;
+
+    for (Index = 0; Index < EventCount; Index++) {
+        KeSetEvent( Events[Index],
+                    IO_NO_INCREMENT,
+                    FALSE );
+    }
+}
+
+VOID
+LdkpWakeAllAlertByThreadIdWaiters (
+    VOID
+    )
+{
+    PKEVENT Events[LDK_ALERT_BY_THREAD_ID_WAKE_BATCH];
+    ULONG Count;
+
+    PAGED_CODE();
+
+    do {
+        Count = LdkpCollectAlertByThreadIdEvents( Events,
+                                                  RTL_NUMBER_OF(Events) );
+        LdkpSetAlertByThreadIdEvents( Events,
+                                      Count );
+    } while (Count == RTL_NUMBER_OF(Events));
+}
+
+PKEVENT
+LdkpRemoveAlertByThreadIdWaiterLocked (
+    _In_ PETHREAD Thread
+    )
+{
+    PLIST_ENTRY Current;
+
+    for (Current = LdkpAlertByThreadIdListHead.Flink;
+         Current != &LdkpAlertByThreadIdListHead;
+         Current = Current->Flink) {
+        PLDK_ALERT_BY_THREAD_ID_ENTRY Entry;
+
+        Entry = CONTAINING_RECORD( Current,
+                                   LDK_ALERT_BY_THREAD_ID_ENTRY,
+                                   Links );
+        if (Entry->Thread == Thread) {
+            Entry->InList = FALSE;
+            Entry->Woken = TRUE;
+            RemoveEntryList( &Entry->Links );
+            return Entry->Event;
+        }
+    }
+
+    return NULL;
+}
+
+BOOLEAN
+LdkpHasPendingAlertByThreadIdLocked (
+    _In_ PETHREAD Thread
+    )
+{
+    PLIST_ENTRY Current;
+
+    for (Current = LdkpAlertByThreadIdPendingListHead.Flink;
+         Current != &LdkpAlertByThreadIdPendingListHead;
+         Current = Current->Flink) {
+        PLDK_ALERT_BY_THREAD_ID_PENDING_ENTRY Entry;
+
+        Entry = CONTAINING_RECORD( Current,
+                                   LDK_ALERT_BY_THREAD_ID_PENDING_ENTRY,
+                                   Links );
+        if (Entry->Thread == Thread) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+BOOLEAN
+LdkpRemovePendingAlertByThreadIdLocked (
+    _In_ PETHREAD Thread
+    )
+{
+    PLIST_ENTRY Current;
+
+    for (Current = LdkpAlertByThreadIdPendingListHead.Flink;
+         Current != &LdkpAlertByThreadIdPendingListHead;
+         Current = Current->Flink) {
+        PLDK_ALERT_BY_THREAD_ID_PENDING_ENTRY Entry;
+
+        Entry = CONTAINING_RECORD( Current,
+                                   LDK_ALERT_BY_THREAD_ID_PENDING_ENTRY,
+                                   Links );
+        if (Entry->Thread == Thread) {
+            RemoveEntryList( &Entry->Links );
+            ObDereferenceObject( Entry->Thread );
+            ExFreeToNPagedLookasideList( &LdkpAlertByThreadIdPendingLookaside,
+                                         Entry );
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+VOID
+LdkpClearPendingAlertByThreadIdList (
+    VOID
+    )
+{
+    PLIST_ENTRY ListEntry;
+    KIRQL OldIrql;
+
+    PAGED_CODE();
+
+    for (;;) {
+        OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+        if (IsListEmpty( &LdkpAlertByThreadIdPendingListHead )) {
+            ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                        OldIrql );
+            break;
+        }
+        ListEntry = RemoveHeadList( &LdkpAlertByThreadIdPendingListHead );
+        ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                    OldIrql );
+
+        ObDereferenceObject( CONTAINING_RECORD( ListEntry,
+                                                LDK_ALERT_BY_THREAD_ID_PENDING_ENTRY,
+                                                Links )->Thread );
+        ExFreeToNPagedLookasideList( &LdkpAlertByThreadIdPendingLookaside,
+                                     CONTAINING_RECORD( ListEntry,
+                                                        LDK_ALERT_BY_THREAD_ID_PENDING_ENTRY,
+                                                        Links ) );
+    }
+}
+
+NTSTATUS
+LdkpInitializeAlertByThreadIdList (
+    VOID
+    )
+{
+    PAGED_CODE();
+
+    LdkpAlertByThreadIdListLock = 0;
+    InitializeListHead( &LdkpAlertByThreadIdListHead );
+    InitializeListHead( &LdkpAlertByThreadIdPendingListHead );
+    KeInitializeEvent( &LdkpAlertByThreadIdDrainedEvent,
+                       NotificationEvent,
+                       TRUE );
+    ExInitializeNPagedLookasideList( &LdkpAlertByThreadIdPendingLookaside,
+                                     NULL,
+                                     NULL,
+                                     0,
+                                     sizeof(LDK_ALERT_BY_THREAD_ID_PENDING_ENTRY),
+                                     TAG_ALERT_BY_THREAD_ID_PENDING,
+                                     0 );
+    LdkpAlertByThreadIdWaitCount = 0;
+    LdkpAlertByThreadIdShuttingDown = FALSE;
+    return STATUS_SUCCESS;
+}
+
+VOID
+LdkpTerminateAlertByThreadIdList(
+    VOID
+    )
+{
+    KIRQL OldIrql;
+
+    PAGED_CODE();
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+    LdkpAlertByThreadIdShuttingDown = TRUE;
+    ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                OldIrql );
+
+    LdkpWakeAllAlertByThreadIdWaiters();
+
+    KeWaitForSingleObject( &LdkpAlertByThreadIdDrainedEvent,
+                           Executive,
+                           KernelMode,
+                           FALSE,
+                           NULL );
+
+    LdkpClearPendingAlertByThreadIdList();
+    ExDeleteNPagedLookasideList( &LdkpAlertByThreadIdPendingLookaside );
+}
+
+VOID
+LdkpReferenceAlertByThreadIdWait (
+    VOID
+    )
+{
+    if (InterlockedIncrement( &LdkpAlertByThreadIdWaitCount ) == 1) {
+        KeClearEvent( &LdkpAlertByThreadIdDrainedEvent );
+    }
+}
+
+VOID
+LdkpDereferenceAlertByThreadIdWait (
+    VOID
+    )
+{
+    if (InterlockedDecrement( &LdkpAlertByThreadIdWaitCount ) == 0) {
+        KeSetEvent( &LdkpAlertByThreadIdDrainedEvent,
+                    IO_NO_INCREMENT,
+                    FALSE );
+    }
+}
+
+NTSTATUS
+LdkpLookupTebByThreadId (
+    _In_ HANDLE ThreadId,
+    _Out_ PLDK_TEB* Teb
+    )
+{
+    PETHREAD Thread;
+    NTSTATUS Status;
+
+    *Teb = NULL;
+
+    Status = PsLookupThreadByThreadId( ThreadId,
+                                       &Thread );
+    if (! NT_SUCCESS(Status)) {
+        return Status;
+    }
+
+    *Teb = LdkReferenceTebByThread( Thread );
+    ObDereferenceObject( Thread );
+
+    if (! *Teb) {
+        return STATUS_INVALID_CID;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+NtAlertThreadByThreadId (
+    _In_ HANDLE ThreadId
+    )
+{
+    PLDK_ALERT_BY_THREAD_ID_PENDING_ENTRY PendingEntry = NULL;
+    PETHREAD Thread;
+    PKEVENT Event = NULL;
+    NTSTATUS Status;
+    KIRQL OldIrql;
+
+    PAGED_CODE();
+
+    Status = PsLookupThreadByThreadId( ThreadId,
+                                       &Thread );
+    if (! NT_SUCCESS(Status)) {
+        return Status;
+    }
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+    Event = LdkpRemoveAlertByThreadIdWaiterLocked( Thread );
+    ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                OldIrql );
+
+    if (Event) {
+        ObDereferenceObject( Thread );
+        KeSetEvent( Event,
+                    IO_NO_INCREMENT,
+                    FALSE );
+        return STATUS_SUCCESS;
+    }
+
+    PendingEntry = ExAllocateFromNPagedLookasideList( &LdkpAlertByThreadIdPendingLookaside );
+    if (! PendingEntry) {
+        OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+        Event = LdkpRemoveAlertByThreadIdWaiterLocked( Thread );
+        ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                    OldIrql );
+        if (Event) {
+            ObDereferenceObject( Thread );
+            KeSetEvent( Event,
+                        IO_NO_INCREMENT,
+                        FALSE );
+            return STATUS_SUCCESS;
+        }
+        ObDereferenceObject( Thread );
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    PendingEntry->Thread = Thread;
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+    Event = LdkpRemoveAlertByThreadIdWaiterLocked( Thread );
+    if (! Event) {
+        if (LdkpHasPendingAlertByThreadIdLocked( Thread )) {
+            ExFreeToNPagedLookasideList( &LdkpAlertByThreadIdPendingLookaside,
+                                         PendingEntry );
+            ObDereferenceObject( Thread );
+            PendingEntry = NULL;
+        } else {
+            InsertTailList( &LdkpAlertByThreadIdPendingListHead,
+                            &PendingEntry->Links );
+            PendingEntry = NULL;
+        }
+    }
+    ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                OldIrql );
+
+    if (Event) {
+        if (PendingEntry) {
+            ExFreeToNPagedLookasideList( &LdkpAlertByThreadIdPendingLookaside,
+                                         PendingEntry );
+            ObDereferenceObject( Thread );
+        }
+        KeSetEvent( Event,
+                    IO_NO_INCREMENT,
+                    FALSE );
+    }
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+NtWaitForAlertByThreadId (
+    _In_opt_ PVOID Address,
+    _In_opt_ PLARGE_INTEGER Timeout
+    )
+{
+    LDK_ALERT_BY_THREAD_ID_ENTRY Entry;
+    KEVENT Event;
+    PLDK_TEB Teb;
+    NTSTATUS Status;
+    BOOLEAN Woken;
+    KIRQL OldIrql;
+
+    PAGED_CODE();
+
+    UNREFERENCED_PARAMETER(Address);
+
+    Teb = NtCurrentTeb();
+
+    KeInitializeEvent( &Event,
+                       SynchronizationEvent,
+                       FALSE );
+
+    RtlZeroMemory( &Entry,
+                   sizeof(Entry) );
+    Entry.Thread = PsGetCurrentThread();
+    Entry.Event = &Event;
+    Entry.InList = TRUE;
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+    if (LdkpAlertByThreadIdShuttingDown ||
+        LDK_IS_SHUTDOWN_IN_PROGRESS) {
+        ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                    OldIrql );
+        return STATUS_DELETE_PENDING;
+    }
+
+    LdkpReferenceAlertByThreadIdWait();
+
+    if (LdkpRemovePendingAlertByThreadIdLocked( PsGetCurrentThread() ) ||
+        Teb->AlertByThreadIdPending) {
+        Teb->AlertByThreadIdPending = FALSE;
+        ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                    OldIrql );
+        LdkpDereferenceAlertByThreadIdWait();
+        return STATUS_ALERTED;
+    }
+    InsertTailList( &LdkpAlertByThreadIdListHead,
+                    &Entry.Links );
+    ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                OldIrql );
+
+    Status = KeWaitForSingleObject( &Event,
+                                    Executive,
+                                    KernelMode,
+                                    FALSE,
+                                    Timeout );
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpAlertByThreadIdListLock );
+    Woken = Entry.Woken;
+    if (Entry.InList) {
+        Entry.InList = FALSE;
+        RemoveEntryList( &Entry.Links );
+    }
+    ExReleaseSpinLockExclusive( &LdkpAlertByThreadIdListLock,
+                                OldIrql );
+
+    if (Woken &&
+        Status != STATUS_SUCCESS) {
+        Status = KeWaitForSingleObject( &Event,
+                                        Executive,
+                                        KernelMode,
+                                        FALSE,
+                                        NULL );
+    }
+
+    if (Status == STATUS_SUCCESS) {
+        LdkpDereferenceAlertByThreadIdWait();
+        return STATUS_ALERTED;
+    }
+
+    LdkpDereferenceAlertByThreadIdWait();
+    return Status;
+}

--- a/src/ntdll/ntdll.c
+++ b/src/ntdll/ntdll.c
@@ -56,6 +56,34 @@ LDK_FUNCTION_REGISTRATION LdkpNtdllFunctionRegistration[] = {
         RtlWakeAllConditionVariable
     },
     {
+        "RtlWaitOnAddress",
+        RtlWaitOnAddress
+    },
+    {
+        "RtlWakeAddressSingle",
+        RtlWakeAddressSingle
+    },
+    {
+        "RtlWakeAddressAll",
+        RtlWakeAddressAll
+    },
+    {
+        "NtAlertThreadByThreadId",
+        NtAlertThreadByThreadId
+    },
+    {
+        "NtWaitForAlertByThreadId",
+        NtWaitForAlertByThreadId
+    },
+    {
+        "ZwAlertThreadByThreadId",
+        ZwAlertThreadByThreadId
+    },
+    {
+        "ZwWaitForAlertByThreadId",
+        ZwWaitForAlertByThreadId
+    },
+    {
         "RtlInitializeCriticalSection",
         RtlInitializeCriticalSection
     },
@@ -121,6 +149,12 @@ LDK_TERMINATE_COMPONENT LdkpTerminateCurDir;
 LDK_INITIALIZE_COMPONENT LdkpInitializeKeyedEventList;
 LDK_TERMINATE_COMPONENT LdkpTerminateKeyedEventList;
 
+LDK_INITIALIZE_COMPONENT LdkpInitializeAlertByThreadIdList;
+LDK_TERMINATE_COMPONENT LdkpTerminateAlertByThreadIdList;
+
+LDK_INITIALIZE_COMPONENT LdkpInitializeWaitOnAddressList;
+LDK_TERMINATE_COMPONENT LdkpTerminateWaitOnAddressList;
+
 LDK_INITIALIZE_COMPONENT LdkpInitializeRtlWorkItem;
 LDK_TERMINATE_COMPONENT LdkpTerminateRtlWorkItem;
 
@@ -150,8 +184,23 @@ LdkpNtdllInitialize (
         return Status;
     }
 
+    Status = LdkpInitializeAlertByThreadIdList();
+    if (! NT_SUCCESS(Status)) {
+        LdkpTerminateKeyedEventList();
+        return Status;
+    }
+
+    Status = LdkpInitializeWaitOnAddressList();
+    if (! NT_SUCCESS(Status)) {
+        LdkpTerminateAlertByThreadIdList();
+        LdkpTerminateKeyedEventList();
+        return Status;
+    }
+
     Status = LdkpInitializeRtlWorkItem();
     if (! NT_SUCCESS(Status)) {
+        LdkpTerminateWaitOnAddressList();
+        LdkpTerminateAlertByThreadIdList();
         LdkpTerminateKeyedEventList();
         return Status;
     }
@@ -175,6 +224,10 @@ LdkpNtdllTerminate(
     RtlpDeleteDeferedCriticalSection();
 
     LdkpTerminateRtlWorkItem();
+
+    LdkpTerminateWaitOnAddressList();
+
+    LdkpTerminateAlertByThreadIdList();
 
 	LdkpTerminateKeyedEventList();
 }

--- a/src/ntdll/waitonaddress.c
+++ b/src/ntdll/waitonaddress.c
@@ -1,0 +1,354 @@
+#include "ntdll.h"
+
+
+
+#define LDK_WAIT_ON_ADDRESS_WAKE_BATCH 64
+
+typedef struct _LDK_WAIT_ON_ADDRESS_ENTRY {
+    LIST_ENTRY Links;
+    PVOID Address;
+    HANDLE ThreadId;
+    BOOLEAN InList;
+    BOOLEAN Woken;
+} LDK_WAIT_ON_ADDRESS_ENTRY, *PLDK_WAIT_ON_ADDRESS_ENTRY;
+
+EX_SPIN_LOCK LdkpWaitOnAddressListLock;
+LIST_ENTRY LdkpWaitOnAddressListHead;
+KEVENT LdkpWaitOnAddressDrainedEvent;
+LONG LdkpWaitOnAddressWaitCount;
+BOOLEAN LdkpWaitOnAddressShuttingDown;
+
+
+
+NTSTATUS
+LdkpInitializeWaitOnAddressList (
+    VOID
+    );
+
+VOID
+LdkpTerminateWaitOnAddressList(
+    VOID
+    );
+
+VOID
+LdkpReferenceWaitOnAddressWait (
+    VOID
+    );
+
+VOID
+LdkpDereferenceWaitOnAddressWait (
+    VOID
+    );
+
+VOID
+LdkpWakeAllAlertByThreadIdWaiters (
+    VOID
+    );
+
+
+
+#ifdef ALLOC_PRAGMA
+#pragma alloc_text(INIT, LdkpInitializeWaitOnAddressList)
+#pragma alloc_text(PAGE, LdkpTerminateWaitOnAddressList)
+#pragma alloc_text(PAGE, RtlWaitOnAddress)
+#pragma alloc_text(PAGE, RtlWakeAddressSingle)
+#pragma alloc_text(PAGE, RtlWakeAddressAll)
+#endif
+
+
+
+BOOLEAN
+LdkpWaitOnAddressValuesMatch (
+    _In_reads_bytes_(AddressSize) volatile VOID* Address,
+    _In_reads_bytes_(AddressSize) PVOID CompareAddress,
+    _In_ SIZE_T AddressSize
+    )
+{
+    switch (AddressSize) {
+    case sizeof(UCHAR):
+        return *((volatile UCHAR*)Address) == *((PUCHAR)CompareAddress);
+    case sizeof(USHORT):
+        return *((volatile USHORT*)Address) == *((PUSHORT)CompareAddress);
+    case sizeof(ULONG):
+        return *((volatile ULONG*)Address) == *((PULONG)CompareAddress);
+    case sizeof(ULONGLONG):
+        return *((volatile ULONGLONG*)Address) == *((PULONGLONG)CompareAddress);
+    default:
+        return FALSE;
+    }
+}
+
+ULONG
+LdkpCollectWaitOnAddressThreadIds (
+    _In_opt_ PVOID Address,
+    _In_ BOOLEAN WakeAll,
+    _Out_writes_(ThreadIdCount) PHANDLE ThreadIds,
+    _In_ ULONG ThreadIdCount
+    )
+{
+    ULONG Count = 0;
+    PLIST_ENTRY Current;
+    KIRQL OldIrql;
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpWaitOnAddressListLock );
+    Current = LdkpWaitOnAddressListHead.Flink;
+    while (Current != &LdkpWaitOnAddressListHead && Count < ThreadIdCount) {
+        PLDK_WAIT_ON_ADDRESS_ENTRY Entry;
+        PLIST_ENTRY Next;
+
+        Next = Current->Flink;
+        Entry = CONTAINING_RECORD( Current,
+                                   LDK_WAIT_ON_ADDRESS_ENTRY,
+                                   Links );
+        if (! Address || Entry->Address == Address) {
+            Entry->InList = FALSE;
+            Entry->Woken = TRUE;
+            RemoveEntryList( &Entry->Links );
+            ThreadIds[Count++] = Entry->ThreadId;
+            if (! WakeAll) {
+                break;
+            }
+        }
+
+        Current = Next;
+    }
+    ExReleaseSpinLockExclusive( &LdkpWaitOnAddressListLock,
+                                OldIrql );
+
+    return Count;
+}
+
+VOID
+LdkpAlertThreadIds (
+    _In_reads_(ThreadIdCount) PHANDLE ThreadIds,
+    _In_ ULONG ThreadIdCount
+    )
+{
+    ULONG Index;
+
+    for (Index = 0; Index < ThreadIdCount; Index++) {
+        NtAlertThreadByThreadId( ThreadIds[Index] );
+    }
+}
+
+NTSTATUS
+LdkpInitializeWaitOnAddressList (
+    VOID
+    )
+{
+    PAGED_CODE();
+
+    LdkpWaitOnAddressListLock = 0;
+    InitializeListHead( &LdkpWaitOnAddressListHead );
+    KeInitializeEvent( &LdkpWaitOnAddressDrainedEvent,
+                       NotificationEvent,
+                       TRUE );
+    LdkpWaitOnAddressWaitCount = 0;
+    LdkpWaitOnAddressShuttingDown = FALSE;
+    return STATUS_SUCCESS;
+}
+
+VOID
+LdkpTerminateWaitOnAddressList(
+    VOID
+    )
+{
+    HANDLE ThreadIds[LDK_WAIT_ON_ADDRESS_WAKE_BATCH];
+    ULONG Count;
+    KIRQL OldIrql;
+
+    PAGED_CODE();
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpWaitOnAddressListLock );
+    LdkpWaitOnAddressShuttingDown = TRUE;
+    ExReleaseSpinLockExclusive( &LdkpWaitOnAddressListLock,
+                                OldIrql );
+
+    do {
+        Count = LdkpCollectWaitOnAddressThreadIds( NULL,
+                                                   TRUE,
+                                                   ThreadIds,
+                                                   RTL_NUMBER_OF(ThreadIds) );
+        LdkpAlertThreadIds( ThreadIds,
+                            Count );
+    } while (Count == RTL_NUMBER_OF(ThreadIds));
+
+    LdkpWakeAllAlertByThreadIdWaiters();
+
+    KeWaitForSingleObject( &LdkpWaitOnAddressDrainedEvent,
+                           Executive,
+                           KernelMode,
+                           FALSE,
+                           NULL );
+}
+
+VOID
+LdkpReferenceWaitOnAddressWait (
+    VOID
+    )
+{
+    if (InterlockedIncrement( &LdkpWaitOnAddressWaitCount ) == 1) {
+        KeClearEvent( &LdkpWaitOnAddressDrainedEvent );
+    }
+}
+
+VOID
+LdkpDereferenceWaitOnAddressWait (
+    VOID
+    )
+{
+    if (InterlockedDecrement( &LdkpWaitOnAddressWaitCount ) == 0) {
+        KeSetEvent( &LdkpWaitOnAddressDrainedEvent,
+                    IO_NO_INCREMENT,
+                    FALSE );
+    }
+}
+
+NTSTATUS
+NTAPI
+RtlWaitOnAddress (
+    _In_reads_bytes_(AddressSize) volatile VOID* Address,
+    _In_reads_bytes_(AddressSize) PVOID CompareAddress,
+    _In_ SIZE_T AddressSize,
+    _In_opt_ PLARGE_INTEGER Timeout
+    )
+{
+    LDK_WAIT_ON_ADDRESS_ENTRY Entry;
+    NTSTATUS Status;
+    BOOLEAN Woken;
+    KIRQL OldIrql;
+
+    PAGED_CODE();
+
+    if (! ARGUMENT_PRESENT(Address) ||
+        ! ARGUMENT_PRESENT(CompareAddress) ||
+        (AddressSize != sizeof(UCHAR) &&
+         AddressSize != sizeof(USHORT) &&
+         AddressSize != sizeof(ULONG) &&
+         AddressSize != sizeof(ULONGLONG))) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    if (! LdkpWaitOnAddressValuesMatch( Address,
+                                        CompareAddress,
+                                        AddressSize )) {
+        return STATUS_SUCCESS;
+    }
+
+    RtlZeroMemory( &Entry,
+                   sizeof(Entry) );
+    Entry.Address = (PVOID)Address;
+    Entry.ThreadId = PsGetCurrentThreadId();
+    Entry.InList = TRUE;
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpWaitOnAddressListLock );
+    if (LdkpWaitOnAddressShuttingDown ||
+        LDK_IS_SHUTDOWN_IN_PROGRESS) {
+        ExReleaseSpinLockExclusive( &LdkpWaitOnAddressListLock,
+                                    OldIrql );
+        return STATUS_DELETE_PENDING;
+    }
+
+    if (! LdkpWaitOnAddressValuesMatch( Address,
+                                        CompareAddress,
+                                        AddressSize )) {
+        Entry.InList = FALSE;
+        ExReleaseSpinLockExclusive( &LdkpWaitOnAddressListLock,
+                                    OldIrql );
+        return STATUS_SUCCESS;
+    }
+
+    LdkpReferenceWaitOnAddressWait();
+
+    InsertTailList( &LdkpWaitOnAddressListHead,
+                    &Entry.Links );
+
+    if (! LdkpWaitOnAddressValuesMatch( Address,
+                                        CompareAddress,
+                                        AddressSize )) {
+        Entry.InList = FALSE;
+        RemoveEntryList( &Entry.Links );
+        ExReleaseSpinLockExclusive( &LdkpWaitOnAddressListLock,
+                                    OldIrql );
+        LdkpDereferenceWaitOnAddressWait();
+        return STATUS_SUCCESS;
+    }
+    ExReleaseSpinLockExclusive( &LdkpWaitOnAddressListLock,
+                                OldIrql );
+
+    Status = NtWaitForAlertByThreadId( NULL,
+                                       Timeout );
+
+    OldIrql = ExAcquireSpinLockExclusive( &LdkpWaitOnAddressListLock );
+    Woken = Entry.Woken;
+    if (Entry.InList) {
+        Entry.InList = FALSE;
+        RemoveEntryList( &Entry.Links );
+    }
+    ExReleaseSpinLockExclusive( &LdkpWaitOnAddressListLock,
+                                OldIrql );
+
+    if (Woken &&
+        Status != STATUS_ALERTED &&
+        Status != STATUS_SUCCESS) {
+        Status = NtWaitForAlertByThreadId( NULL,
+                                           NULL );
+    }
+
+    if (Status == STATUS_ALERTED) {
+        Status = STATUS_SUCCESS;
+    }
+
+    LdkpDereferenceWaitOnAddressWait();
+    return Status;
+}
+
+VOID
+NTAPI
+RtlWakeAddressSingle (
+    _In_ PVOID Address
+    )
+{
+    HANDLE ThreadId;
+    ULONG Count;
+
+    PAGED_CODE();
+
+    if (! ARGUMENT_PRESENT(Address)) {
+        return;
+    }
+
+    Count = LdkpCollectWaitOnAddressThreadIds( Address,
+                                               FALSE,
+                                               &ThreadId,
+                                               1 );
+    if (Count) {
+        LdkpAlertThreadIds( &ThreadId,
+                            Count );
+    }
+}
+
+VOID
+NTAPI
+RtlWakeAddressAll (
+    _In_ PVOID Address
+    )
+{
+    HANDLE ThreadIds[LDK_WAIT_ON_ADDRESS_WAKE_BATCH];
+    ULONG Count;
+
+    PAGED_CODE();
+
+    if (! ARGUMENT_PRESENT(Address)) {
+        return;
+    }
+
+    do {
+        Count = LdkpCollectWaitOnAddressThreadIds( Address,
+                                                   TRUE,
+                                                   ThreadIds,
+                                                   RTL_NUMBER_OF(ThreadIds) );
+        LdkpAlertThreadIds( ThreadIds,
+                            Count );
+    } while (Count == RTL_NUMBER_OF(ThreadIds));
+}

--- a/src/peb.c
+++ b/src/peb.c
@@ -38,7 +38,11 @@ LdkpDriverDispatchCreateClose (
     )
 {
     UNREFERENCED_PARAMETER(DeviceObject);
-    UNREFERENCED_PARAMETER(Irp);
+
+    Irp->IoStatus.Status = STATUS_SUCCESS;
+    Irp->IoStatus.Information = 0;
+    IoCompleteRequest( Irp,
+                       IO_NO_INCREMENT );
     return STATUS_SUCCESS;
 }
 
@@ -52,7 +56,11 @@ LdkpDriverDispatchReadWrite (
     )
 {
     UNREFERENCED_PARAMETER(DeviceObject);
-    UNREFERENCED_PARAMETER(Irp);
+
+    Irp->IoStatus.Status = STATUS_SUCCESS;
+    Irp->IoStatus.Information = 0;
+    IoCompleteRequest( Irp,
+                       IO_NO_INCREMENT );
     return STATUS_SUCCESS;
 }
 
@@ -66,7 +74,11 @@ LdkpDriverDispatchOther (
     )
 {
     UNREFERENCED_PARAMETER(DeviceObject);
-    UNREFERENCED_PARAMETER(Irp);
+
+    Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;
+    Irp->IoStatus.Information = 0;
+    IoCompleteRequest( Irp,
+                       IO_NO_INCREMENT );
     return STATUS_INVALID_DEVICE_REQUEST;
 }
 
@@ -79,23 +91,29 @@ LdkpUninitializeStdio (
 
     if (LdkpStdInHandle) {
         ZwClose(LdkpStdInHandle);
+        LdkpStdInHandle = NULL;
     }
     if (LdkpStdInDeviceObject) {
         IoDeleteDevice( LdkpStdInDeviceObject );
+        LdkpStdInDeviceObject = NULL;
     }
 
     if (LdkpStdOutHandle) {
         ZwClose(LdkpStdOutHandle);
+        LdkpStdOutHandle = NULL;
     }
     if (LdkpStdOutDeviceObject) {
         IoDeleteDevice( LdkpStdOutDeviceObject );
+        LdkpStdOutDeviceObject = NULL;
     }
 
     if (LdkpStdErrHandle) {
         ZwClose(LdkpStdErrHandle);
+        LdkpStdErrHandle = NULL;
     }
     if (LdkpStdErrorDeviceObject) {
         IoDeleteDevice( LdkpStdErrorDeviceObject );
+        LdkpStdErrorDeviceObject = NULL;
     }
 }
 
@@ -226,7 +244,7 @@ LdkpInitializeProcessParameters (
                                                          LdkpProcessParameters.EnvironmentSize );
 	if (! LdkpProcessParameters.Environment) {
         LdkpUninitializeStdio();
-		return Status;
+		return STATUS_INSUFFICIENT_RESOURCES;
 	}
 
     UNICODE_STRING Name;
@@ -326,6 +344,7 @@ LdkpInitializeProcessParameters (
                                    Path.MaximumLength );
     if (! Path.Buffer) {
         LdkpUninitializeProcessParameters();
+        return STATUS_INSUFFICIENT_RESOURCES;
     }
     RtlCopyUnicodeString( &Path,
                           &LdkpProcessParameters.DllPath );
@@ -355,13 +374,16 @@ LdkpUninitializeProcessParameters (
     VOID
     )
 {
-    if (! LdkIsConsoleHandle( LdkpProcessParameters.StandardInput )) {
+    if (LdkpProcessParameters.StandardInput &&
+        ! LdkIsConsoleHandle( LdkpProcessParameters.StandardInput )) {
         ZwClose( LdkpProcessParameters.StandardInput );
     }
-    if (! LdkIsConsoleHandle( LdkpProcessParameters.StandardOutput )) {
+    if (LdkpProcessParameters.StandardOutput &&
+        ! LdkIsConsoleHandle( LdkpProcessParameters.StandardOutput )) {
         ZwClose( LdkpProcessParameters.StandardOutput );
     }
-    if (! LdkIsConsoleHandle( LdkpProcessParameters.StandardError )) {
+    if (LdkpProcessParameters.StandardError &&
+        ! LdkIsConsoleHandle( LdkpProcessParameters.StandardError )) {
         ZwClose( LdkpProcessParameters.StandardError );
     }
 
@@ -540,5 +562,8 @@ LdkIsConsoleHandle (
 	_In_ HANDLE Handle
 	)
 {
-	return (LdkpStdInHandle == Handle) || (LdkpStdOutHandle == Handle) || (LdkpStdErrHandle == Handle);
+	return Handle != NULL &&
+           ((LdkpStdInHandle == Handle) ||
+            (LdkpStdOutHandle == Handle) ||
+            (LdkpStdErrHandle == Handle));
 }

--- a/src/teb.c
+++ b/src/teb.c
@@ -102,6 +102,43 @@ LdkLookTebByThread (
 	return NULL;
 }
 
+PLDK_TEB
+LdkReferenceTebByThread (
+	_In_ PETHREAD Thread
+	)
+{
+	PLDK_TEB Teb;
+	PLIST_ENTRY NextEntry;
+	KIRQL OldIrql= ExAcquireSpinLockShared( &LdkpTebListLock );
+
+	for (NextEntry = LdkpTebListHead.Flink;
+		NextEntry != &LdkpTebListHead;
+		NextEntry = NextEntry->Flink) {
+
+		Teb = CONTAINING_RECORD(NextEntry, LDK_TEB, ActiveLinks);
+
+		if (Teb->Thread == Thread &&
+			ExAcquireRundownProtection( &Teb->RundownProtect )) {
+			ExReleaseSpinLockShared( &LdkpTebListLock,
+									 OldIrql );
+			return Teb;
+		}
+
+	}
+
+	ExReleaseSpinLockShared( &LdkpTebListLock,
+							 OldIrql );
+	return NULL;
+}
+
+VOID
+LdkDereferenceTeb (
+	_Inout_ PLDK_TEB Teb
+	)
+{
+	ExReleaseRundownProtection( &Teb->RundownProtect );
+}
+
 PTEB
 LdkGetNextTebRundownProtection (
 	_In_ PTEB Teb
@@ -235,7 +272,7 @@ LdkpInvokeFlsCallback (
 #pragma warning(default:4055)
 			Data = InterlockedExchangePointer( &Teb->FlsSlots[i],
 											   NULL );
-			if (Callback) {
+			if (Callback && Data) {
 				Callback(Data);
 			}				
 		}
@@ -321,6 +358,8 @@ LdkpInitializeTeb (
 						   1L );
 	InitializeListHead( &Teb->KeyedWaitChain );
 	Teb->KeyedWaitValue = NULL;
+
+	Teb->AlertByThreadIdPending = FALSE;
 
 	Teb->ClientId.UniqueProcess = PsGetCurrentProcessId();
 	Teb->ClientId.UniqueThread = PsGetThreadId( Thread );

--- a/src/teb.h
+++ b/src/teb.h
@@ -26,6 +26,8 @@ typedef struct _LDK_TEB {
 
 	PVOID KeyedWaitValue;
 
+	BOOLEAN AlertByThreadIdPending;
+
 	ULONG HardErrorsAreDisabled;
 
 	UNICODE_STRING StaticUnicodeString;
@@ -50,6 +52,21 @@ typedef struct _LDK_TEB {
 PLDK_TEB
 LdkCurrentTeb (
 	VOID
+	);
+
+PLDK_TEB
+LdkLookTebByThread (
+	_In_ PETHREAD Thread
+	);
+
+PLDK_TEB
+LdkReferenceTebByThread (
+	_In_ PETHREAD Thread
+	);
+
+VOID
+LdkDereferenceTeb (
+	_Inout_ PLDK_TEB Teb
 	);
 
 

--- a/test/driver.c
+++ b/test/driver.c
@@ -70,6 +70,11 @@ KeyedEventTest (
     VOID
     );
 
+BOOLEAN
+WaitOnAddressTest (
+    VOID
+    );
+
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(INIT, DriverEntry)
 #pragma alloc_text(PAGE, DriverUnload)
@@ -86,27 +91,33 @@ LDK_TEST_ROUTINE (
 
 typedef LDK_TEST_ROUTINE *PLDK_TEST_ROUTINE;
 
+typedef struct _LDK_TEST_ENTRY {
+    PCSTR Name;
+    PLDK_TEST_ROUTINE Routine;
+} LDK_TEST_ENTRY, *PLDK_TEST_ENTRY;
+
 NTSTATUS
 DriverEntry (
     _In_ PDRIVER_OBJECT DriverObject,
     _In_ PUNICODE_STRING RegistryPath
     )
 {
-    PLDK_TEST_ROUTINE Tests[] = {
-        NtdllCurrentDirectoryTest,
-        NtdllEnvironmentVariableTest,
-        KeyedEventTest,
-        LdrTest,
-        FibersTest,
-        FileTest,
-        CurrentDirectoryTest,
-        EnvironmentVariableTest,
-        LegacyThreadPoolTest,
-        ThreadPoolTest,
-        ConditionVariableTest,
-        LibraryTest,
-        ConsoleTest,
-        NULL
+    LDK_TEST_ENTRY Tests[] = {
+        { "NtdllCurrentDirectoryTest", NtdllCurrentDirectoryTest },
+        { "NtdllEnvironmentVariableTest", NtdllEnvironmentVariableTest },
+        { "KeyedEventTest", KeyedEventTest },
+        { "LdrTest", LdrTest },
+        { "FibersTest", FibersTest },
+        { "FileTest", FileTest },
+        { "CurrentDirectoryTest", CurrentDirectoryTest },
+        { "EnvironmentVariableTest", EnvironmentVariableTest },
+        { "LegacyThreadPoolTest", LegacyThreadPoolTest },
+        { "ThreadPoolTest", ThreadPoolTest },
+        { "ConditionVariableTest", ConditionVariableTest },
+        { "WaitOnAddressTest", WaitOnAddressTest },
+        { "LibraryTest", LibraryTest },
+        { "ConsoleTest", ConsoleTest },
+        { NULL, NULL }
     };
 
     KdBreakPoint();
@@ -115,12 +126,30 @@ DriverEntry (
 
     UNREFERENCED_PARAMETER(RegistryPath);
 
-    for (PLDK_TEST_ROUTINE *test = Tests; *test; test++) {
-        if (! (*test)()) {
+    for (PLDK_TEST_ENTRY Test = Tests; Test->Routine; Test++) {
+        DbgPrintEx( DPFLTR_IHVDRIVER_ID,
+                    DPFLTR_INFO_LEVEL,
+                    "[LdkTest] RUN  %s\n",
+                    Test->Name );
+
+        if (! Test->Routine()) {
+            DbgPrintEx( DPFLTR_IHVDRIVER_ID,
+                        DPFLTR_ERROR_LEVEL,
+                        "[LdkTest] FAIL %s\n",
+                        Test->Name );
             LdkTerminate();
             return STATUS_UNSUCCESSFUL;
         }
+
+        DbgPrintEx( DPFLTR_IHVDRIVER_ID,
+                    DPFLTR_INFO_LEVEL,
+                    "[LdkTest] PASS %s\n",
+                    Test->Name );
     }
+
+    DbgPrintEx( DPFLTR_IHVDRIVER_ID,
+                DPFLTR_INFO_LEVEL,
+                "[LdkTest] PASS all tests\n" );
 
     DriverObject->DriverUnload = DriverUnload;
     return STATUS_SUCCESS;

--- a/test/kernel32/console.c
+++ b/test/kernel32/console.c
@@ -24,58 +24,120 @@ ConsoleTest (
     VOID
     )
 {
+    BOOLEAN rv = TRUE;
+    DWORD mode;
+    DWORD written;
+
     PAGED_CODE();
 
+    HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
     HANDLE hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+
+    printf("Test SetConsoleMode/GetConsoleMode(hStdIn)\n");
+    if (! SetConsoleMode( hStdIn,
+                          ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT ) ||
+        ! GetConsoleMode( hStdIn,
+                          &mode ) ||
+        mode != (ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT)) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetConsoleMode/GetConsoleMode(hStdIn)\n\n");
+        rv = FALSE;
+    } else {
+        printf("[Success] Test SetConsoleMode/GetConsoleMode(hStdIn)\n\n");
+    }
+
+    printf("Test SetConsoleMode/GetConsoleMode(hStdOut)\n");
+    if (! SetConsoleMode( hStdOut,
+                          ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT ) ||
+        ! GetConsoleMode( hStdOut,
+                          &mode ) ||
+        mode != (ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT)) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetConsoleMode/GetConsoleMode(hStdOut)\n\n");
+        rv = FALSE;
+    } else {
+        printf("[Success] Test SetConsoleMode/GetConsoleMode(hStdOut)\n\n");
+    }
+
     printf("Test WriteConsoleA(hStdOut, test, 4)\n");
-    if (WriteConsoleA( hStdOut, "test", 4, NULL, NULL )) {
+    if (WriteConsoleA( hStdOut, "test", 4, &written, NULL ) &&
+        written == 4) {
         printf("[Success] Test WriteConsoleA(hStdOut, test, 4)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleA(hStdOut, test, 4)\n\n");
     }
     printf("Test WriteConsoleW(hStdOut, test, 4)\n");
-    if (WriteConsoleW( hStdOut, L"test", 4, NULL, NULL )) {
+    if (WriteConsoleW( hStdOut, L"test", 4, &written, NULL ) &&
+        written == 4) {
         printf("[Success] Test WriteConsoleW(hStdOut, test, 4)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleW(hStdOut, test, 4)\n\n");
     }
     printf("Test WriteConsoleA(hStdOut, test, 1)\n");
-    if (WriteConsoleA( hStdOut, "test", 1, NULL, NULL )) {
+    if (WriteConsoleA( hStdOut, "test", 1, &written, NULL ) &&
+        written == 1) {
         printf("[Success] Test WriteConsoleA(hStdOut, test, 1)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleA(hStdOut, test, 1)\n\n");
     }
     printf("Test WriteConsoleW(hStdOut, test, 1)\n");
-    if (WriteConsoleW( hStdOut, L"test", 1, NULL, NULL )) {
+    if (WriteConsoleW( hStdOut, L"test", 1, &written, NULL ) &&
+        written == 1) {
         printf("[Success] Test WriteConsoleW(hStdOut, test, 1)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleW(hStdOut, test, 1)\n\n");
     }
 
-    HANDLE hStdErr = GetStdHandle(STD_OUTPUT_HANDLE);
+    HANDLE hStdErr = GetStdHandle(STD_ERROR_HANDLE);
+
+    printf("Test SetConsoleMode/GetConsoleMode(hStdErr)\n");
+    if (! SetConsoleMode( hStdErr,
+                          ENABLE_PROCESSED_OUTPUT ) ||
+        ! GetConsoleMode( hStdErr,
+                          &mode ) ||
+        mode != ENABLE_PROCESSED_OUTPUT) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetConsoleMode/GetConsoleMode(hStdErr)\n\n");
+        rv = FALSE;
+    } else {
+        printf("[Success] Test SetConsoleMode/GetConsoleMode(hStdErr)\n\n");
+    }
+
     printf("Test WriteConsoleA(hStdErr, test, 4)\n");
-    if (WriteConsoleA( hStdErr, "test", 4, NULL, NULL )) {
+    if (WriteConsoleA( hStdErr, "test", 4, &written, NULL ) &&
+        written == 4) {
         printf("[Success] Test WriteConsoleA(hStdErr, test, 4)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleA(hStdErr, test, 4)\n\n");
     }
     printf("Test WriteConsoleW(hStdErr, test, 4)\n");
-    if (WriteConsoleW( hStdErr, L"test", 4, NULL, NULL )) {
+    if (WriteConsoleW( hStdErr, L"test", 4, &written, NULL ) &&
+        written == 4) {
         printf("[Success] Test WriteConsoleW(hStdErr, test, 4)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleW(hStdErr, test, 4)\n\n");
     }
     printf("Test WriteConsoleA(hStdErr, test, 1)\n");
-    if (WriteConsoleA( hStdErr, "test", 1, NULL, NULL )) {
+    if (WriteConsoleA( hStdErr, "test", 1, &written, NULL ) &&
+        written == 1) {
         printf("[Success] Test WriteConsoleA(hStdErr, test, 1)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleA(hStdErr, test, 1)\n\n");
     }
     printf("Test WriteConsoleW(hStdErr, test, 1)\n");
-    if (WriteConsoleW( hStdErr, L"test", 1, NULL, NULL )) {
+    if (WriteConsoleW( hStdErr, L"test", 1, &written, NULL ) &&
+        written == 1) {
         printf("[Success] Test WriteConsoleW(hStdErr, test, 1)\n\n");
     } else {
+        rv = FALSE;
         printf("[Failed] Test WriteConsoleW(hStdErr, test, 1)\n\n");
     }
-    return TRUE;
+    return rv;
 }

--- a/test/kernel32/environ.c
+++ b/test/kernel32/environ.c
@@ -19,13 +19,19 @@ EnvironmentVariableTest (
 #define PAGED_CODE()
 #endif
 
+#ifndef ERROR_ENVVAR_NOT_FOUND
+#define ERROR_ENVVAR_NOT_FOUND 203L
+#endif
+
 BOOLEAN
 EnvironmentVariableTest (
     VOID
     )
 {
+    BOOLEAN Result;
     PAGED_CODE();
 
+    Result = TRUE;
     printf("EnvironmentVariable Test\n");
 
     CHAR buffer[128];    
@@ -36,6 +42,7 @@ EnvironmentVariableTest (
     if (length == 0) {
         fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
         printf("[Failed] GetEnvironmentVariableA(windir)\n\n");
+        Result = FALSE;
     } else {
         printf("%s\n", buffer);
         printf("[Success] GetEnvironmentVariableA(windir)\n\n");
@@ -47,6 +54,7 @@ EnvironmentVariableTest (
     if (length == 0) {
         fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
         printf("[Failed] GetEnvironmentVariableW(SystemRoot)\n\n");
+        Result = FALSE;
     } else {
         printf("%ws\n", wbuffer);
         printf("[Success] GetEnvironmentVariableW(SystemRoot)\n\n");
@@ -58,6 +66,7 @@ EnvironmentVariableTest (
     } else {
         fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
         printf("[Failed] SetEnvironmentVariableA(TestVar, Test)\n\n");
+        Result = FALSE;
     }
 
     printf("Test GetEnvironmentVariableA(TestVar)\n");
@@ -65,6 +74,7 @@ EnvironmentVariableTest (
     if (length == 0) {
         fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
         printf("[Failed] GetEnvironmentVariableA(TestVar)\n\n");
+        Result = FALSE;
     } else {
         printf("%s\n", buffer);
         printf("[Success] GetEnvironmentVariableA(TestVar)\n\n");
@@ -76,17 +86,28 @@ EnvironmentVariableTest (
     } else {
         fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
         printf("[Failed] SetEnvironmentVariableW(TestVar, NULL)\n\n");
+        Result = FALSE;
     }
 
     printf("Test GetEnvironmentVariableA(TestVar)\n");
     length = GetEnvironmentVariableA( "TestVar", buffer, sizeof(buffer) );
     if (length == 0) {
-        fprintf(stderr, "[Success] ErrorCode = %d\n", GetLastError());
-        printf("[Success] GetEnvironmentVariableA(TestVar)\n\n");
+        DWORD ErrorCode;
+
+        ErrorCode = GetLastError();
+        if (ErrorCode == ERROR_ENVVAR_NOT_FOUND) {
+            printf("[Success] GetEnvironmentVariableA(TestVar) not found ErrorCode = %d\n\n",
+                   ErrorCode);
+        } else {
+            fprintf(stderr, "[Failed] ErrorCode = %d\n", ErrorCode);
+            printf("[Failed] GetEnvironmentVariableA(TestVar)\n\n");
+            Result = FALSE;
+        }
     } else {
         printf("[Failed] %s\n", buffer);
         printf("[Failed] GetEnvironmentVariableA(TestVar)\n\n");
+        Result = FALSE;
     }
 
-    return TRUE;
+    return Result;
 }

--- a/test/kernel32/synchapi.c
+++ b/test/kernel32/synchapi.c
@@ -1,11 +1,2075 @@
 #if _KERNEL_MODE
-#include <Ldk/synchapi.h>
-#else
-#include <synchapi.h>
+#include <Ldk/Windows.h>
+#include <Ldk/ntdll.h>
+
+BOOLEAN
+WaitOnAddressTest (
+    VOID
+    );
+
+DWORD
+WINAPI
+AlertByThreadIdTestThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+WaitOnAddressTestThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+AlertByThreadIdStressThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+AlertByThreadIdTimeoutStressThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+WaitOnAddressStressThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+WaitOnAddressTimeoutThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+RtlWaitOnAddressStressThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+RtlWaitOnAddressTimeoutThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+DWORD
+WINAPI
+WaitOnAddressMixedThreadProc (
+    LPVOID lpThreadParameter
+    );
+
+BOOLEAN
+AlertByThreadIdStressTest (
+    VOID
+    );
+
+BOOLEAN
+NtWaitForAlertByThreadIdTimeoutStressTest (
+    VOID
+    );
+
+BOOLEAN
+WaitOnAddressWakeAllStressTest (
+    VOID
+    );
+
+BOOLEAN
+WaitOnAddressWakeSingleStressTest (
+    VOID
+    );
+
+BOOLEAN
+WaitOnAddressTimeoutStressTest (
+    VOID
+    );
+
+BOOLEAN
+RtlWaitOnAddressWakeAllStressTest (
+    VOID
+    );
+
+BOOLEAN
+RtlWaitOnAddressWakeSingleStressTest (
+    VOID
+    );
+
+BOOLEAN
+RtlWaitOnAddressTimeoutStressTest (
+    VOID
+    );
+
+BOOLEAN
+WaitOnAddressAddressIsolationStressTest (
+    VOID
+    );
+
+BOOLEAN
+WaitOnAddressRepeatedDurabilityStressTest (
+    VOID
+    );
+
+BOOLEAN
+WaitOnAddressSizeMatrixTest (
+    VOID
+    );
+
+BOOLEAN
+WaitOnAddressWaitForCounter (
+    _In_ volatile LONG* Counter,
+    _In_ LONG Expected,
+    _In_ DWORD TimeoutMilliseconds
+    );
+
+#ifdef ALLOC_PRAGMA
+#pragma alloc_text(PAGE, WaitOnAddressTest)
+#pragma alloc_text(PAGE, AlertByThreadIdTestThreadProc)
+#pragma alloc_text(PAGE, WaitOnAddressTestThreadProc)
+#pragma alloc_text(PAGE, AlertByThreadIdStressThreadProc)
+#pragma alloc_text(PAGE, AlertByThreadIdTimeoutStressThreadProc)
+#pragma alloc_text(PAGE, WaitOnAddressStressThreadProc)
+#pragma alloc_text(PAGE, WaitOnAddressTimeoutThreadProc)
+#pragma alloc_text(PAGE, RtlWaitOnAddressStressThreadProc)
+#pragma alloc_text(PAGE, RtlWaitOnAddressTimeoutThreadProc)
+#pragma alloc_text(PAGE, WaitOnAddressMixedThreadProc)
+#pragma alloc_text(PAGE, AlertByThreadIdStressTest)
+#pragma alloc_text(PAGE, NtWaitForAlertByThreadIdTimeoutStressTest)
+#pragma alloc_text(PAGE, WaitOnAddressWakeAllStressTest)
+#pragma alloc_text(PAGE, WaitOnAddressWakeSingleStressTest)
+#pragma alloc_text(PAGE, WaitOnAddressTimeoutStressTest)
+#pragma alloc_text(PAGE, RtlWaitOnAddressWakeAllStressTest)
+#pragma alloc_text(PAGE, RtlWaitOnAddressWakeSingleStressTest)
+#pragma alloc_text(PAGE, RtlWaitOnAddressTimeoutStressTest)
+#pragma alloc_text(PAGE, WaitOnAddressAddressIsolationStressTest)
+#pragma alloc_text(PAGE, WaitOnAddressRepeatedDurabilityStressTest)
+#pragma alloc_text(PAGE, WaitOnAddressSizeMatrixTest)
+#pragma alloc_text(PAGE, WaitOnAddressWaitForCounter)
 #endif
 
-void SynchApiCompileTest()
+#define stdout DPFLTR_INFO_LEVEL
+#define stderr DPFLTR_ERROR_LEVEL
+#define fprintf(_f_, ...)   (DbgPrintEx(DPFLTR_IHVDRIVER_ID, _f_, __VA_ARGS__))
+#define printf(...)         (fprintf(stdout, __VA_ARGS__))
+#else
+#include <windows.h>
+#include <stdio.h>
+#include <winternl.h>
+
+#ifndef NT_SUCCESS
+#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
+#endif
+
+#ifndef STATUS_ALERTED
+#define STATUS_ALERTED ((NTSTATUS)0x00000101)
+#endif
+
+#ifndef STATUS_TIMEOUT
+#define STATUS_TIMEOUT ((NTSTATUS)0x00000102)
+#endif
+
+NTSYSAPI
+NTSTATUS
+NTAPI
+NtAlertThreadByThreadId (
+    _In_ HANDLE ThreadId
+    );
+
+NTSYSAPI
+NTSTATUS
+NTAPI
+NtWaitForAlertByThreadId (
+    _In_opt_ PVOID Address,
+    _In_opt_ PLARGE_INTEGER Timeout
+    );
+
+#pragma comment(lib, "ntdll.lib")
+#define PAGED_CODE()
+#endif
+
+#ifndef STATUS_INVALID_PARAMETER
+#define STATUS_INVALID_PARAMETER ((NTSTATUS)0xC000000D)
+#endif
+
+typedef struct _ALERT_BY_THREAD_ID_TEST_CONTEXT {
+    volatile LONG Ready;
+    volatile LONG Woken;
+    NTSTATUS WaitStatus;
+    DWORD ThreadId;
+} ALERT_BY_THREAD_ID_TEST_CONTEXT, *PALERT_BY_THREAD_ID_TEST_CONTEXT;
+
+typedef struct _WAIT_ON_ADDRESS_TEST_CONTEXT {
+    volatile LONG Value;
+    volatile LONG ReadyCount;
+    volatile LONG WakeCount;
+} WAIT_ON_ADDRESS_TEST_CONTEXT, *PWAIT_ON_ADDRESS_TEST_CONTEXT;
+
+#define ALERT_BY_THREAD_ID_STRESS_THREADS 16
+#define ALERT_BY_THREAD_ID_TIMEOUT_STRESS_THREADS 8
+#define WAIT_ON_ADDRESS_STRESS_THREADS 16
+#define WAIT_ON_ADDRESS_SINGLE_STRESS_THREADS 8
+#define WAIT_ON_ADDRESS_TIMEOUT_STRESS_THREADS 8
+#define WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT 4
+#define WAIT_ON_ADDRESS_MIXED_WAITERS_PER_ADDRESS 4
+#define WAIT_ON_ADDRESS_MIXED_THREADS \
+    (WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT * WAIT_ON_ADDRESS_MIXED_WAITERS_PER_ADDRESS)
+#define WAIT_ON_ADDRESS_DURABILITY_ROUNDS 12
+#define WAIT_ON_ADDRESS_DURABILITY_THREADS 8
+
+typedef struct _ALERT_BY_THREAD_ID_STRESS_CONTEXT {
+    volatile LONG ReadyCount;
+    volatile LONG Start;
+    volatile LONG WokenCount;
+    volatile LONG TimeoutCount;
+    volatile LONG FailedCount;
+    volatile LONG AlertFailedCount;
+    DWORD ThreadIds[ALERT_BY_THREAD_ID_STRESS_THREADS];
+    NTSTATUS Statuses[ALERT_BY_THREAD_ID_STRESS_THREADS];
+} ALERT_BY_THREAD_ID_STRESS_CONTEXT, *PALERT_BY_THREAD_ID_STRESS_CONTEXT;
+
+typedef struct _ALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT {
+    PALERT_BY_THREAD_ID_STRESS_CONTEXT Context;
+    LONG Index;
+} ALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT, *PALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT;
+
+typedef struct _WAIT_ON_ADDRESS_STRESS_CONTEXT {
+    volatile LONG Value;
+    volatile LONG ReadyCount;
+    volatile LONG WakeCount;
+    volatile LONG TimeoutCount;
+    volatile LONG FailedCount;
+    NTSTATUS Statuses[WAIT_ON_ADDRESS_STRESS_THREADS];
+    DWORD LastErrors[WAIT_ON_ADDRESS_STRESS_THREADS];
+} WAIT_ON_ADDRESS_STRESS_CONTEXT, *PWAIT_ON_ADDRESS_STRESS_CONTEXT;
+
+typedef struct _WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT {
+    PWAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    LONG Index;
+} WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT, *PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT;
+
+typedef struct _WAIT_ON_ADDRESS_MIXED_CONTEXT {
+    volatile LONG Values[WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT];
+    volatile LONG ReadyCount;
+    volatile LONG WakeCount;
+    volatile LONG FailedCount;
+    volatile LONG WakeCounts[WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT];
+    NTSTATUS Statuses[WAIT_ON_ADDRESS_MIXED_THREADS];
+    DWORD LastErrors[WAIT_ON_ADDRESS_MIXED_THREADS];
+} WAIT_ON_ADDRESS_MIXED_CONTEXT, *PWAIT_ON_ADDRESS_MIXED_CONTEXT;
+
+typedef struct _WAIT_ON_ADDRESS_MIXED_THREAD_CONTEXT {
+    PWAIT_ON_ADDRESS_MIXED_CONTEXT Context;
+    LONG Index;
+    LONG AddressIndex;
+    BOOLEAN UseRtl;
+} WAIT_ON_ADDRESS_MIXED_THREAD_CONTEXT, *PWAIT_ON_ADDRESS_MIXED_THREAD_CONTEXT;
+
+DWORD
+WINAPI
+AlertByThreadIdTestThreadProc (
+    LPVOID lpThreadParameter
+    )
 {
-    CreateEventA(NULL, FALSE, FALSE, NULL);
-    CreateEventW(NULL, FALSE, FALSE, NULL);
+    PALERT_BY_THREAD_ID_TEST_CONTEXT Context;
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    Context = (PALERT_BY_THREAD_ID_TEST_CONTEXT)lpThreadParameter;
+    Context->ThreadId = GetCurrentThreadId();
+    InterlockedExchange( (PLONG)&Context->Ready,
+                         1 );
+
+    Timeout.QuadPart = -1000 * 10000;
+    Status = NtWaitForAlertByThreadId( NULL,
+                                       &Timeout );
+    Context->WaitStatus = Status;
+    if (Status == STATUS_ALERTED) {
+        InterlockedExchange( (PLONG)&Context->Woken,
+                             1 );
+        return 0;
+    }
+
+    return 1;
+}
+
+DWORD
+WINAPI
+WaitOnAddressTestThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PWAIT_ON_ADDRESS_TEST_CONTEXT Context;
+    LONG Compare;
+
+    PAGED_CODE();
+
+    Context = (PWAIT_ON_ADDRESS_TEST_CONTEXT)lpThreadParameter;
+    Compare = 0;
+
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+    if (WaitOnAddress( &Context->Value,
+                       &Compare,
+                       sizeof(Context->Value),
+                       1000 )) {
+        InterlockedIncrement( (PLONG)&Context->WakeCount );
+        return 0;
+    }
+
+    return 1;
+}
+
+DWORD
+WINAPI
+AlertByThreadIdStressThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT ThreadContext;
+    PALERT_BY_THREAD_ID_STRESS_CONTEXT Context;
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+    LONG Index;
+
+    PAGED_CODE();
+
+    ThreadContext = (PALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT)lpThreadParameter;
+    Context = ThreadContext->Context;
+    Index = ThreadContext->Index;
+
+    Context->ThreadIds[Index] = GetCurrentThreadId();
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+
+    while (! Context->Start) {
+        YieldProcessor();
+    }
+
+    Timeout.QuadPart = -5000LL * 10000;
+    Status = NtWaitForAlertByThreadId( NULL,
+                                       &Timeout );
+    Context->Statuses[Index] = Status;
+
+    if (Status == STATUS_ALERTED) {
+        InterlockedIncrement( (PLONG)&Context->WokenCount );
+        return 0;
+    }
+
+    InterlockedIncrement( (PLONG)&Context->FailedCount );
+    return 1;
+}
+
+DWORD
+WINAPI
+AlertByThreadIdTimeoutStressThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT ThreadContext;
+    PALERT_BY_THREAD_ID_STRESS_CONTEXT Context;
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+    LONG Index;
+
+    PAGED_CODE();
+
+    ThreadContext = (PALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT)lpThreadParameter;
+    Context = ThreadContext->Context;
+    Index = ThreadContext->Index;
+
+    Context->ThreadIds[Index] = GetCurrentThreadId();
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+
+    while (! Context->Start) {
+        YieldProcessor();
+    }
+
+    Timeout.QuadPart = -20LL * 10000;
+    Status = NtWaitForAlertByThreadId( NULL,
+                                       &Timeout );
+    Context->Statuses[Index] = Status;
+
+    if (Status == STATUS_TIMEOUT) {
+        InterlockedIncrement( (PLONG)&Context->TimeoutCount );
+        return 0;
+    }
+
+    InterlockedIncrement( (PLONG)&Context->FailedCount );
+    return 1;
+}
+
+DWORD
+WINAPI
+WaitOnAddressStressThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContext;
+    PWAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    LONG Compare;
+    LONG Index;
+
+    PAGED_CODE();
+
+    ThreadContext = (PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT)lpThreadParameter;
+    Context = ThreadContext->Context;
+    Index = ThreadContext->Index;
+    Compare = 0;
+
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+    if (WaitOnAddress( &Context->Value,
+                       &Compare,
+                       sizeof(Context->Value),
+                       5000 )) {
+        InterlockedIncrement( (PLONG)&Context->WakeCount );
+        return 0;
+    }
+
+    Context->LastErrors[Index] = GetLastError();
+    InterlockedIncrement( (PLONG)&Context->FailedCount );
+    return 1;
+}
+
+DWORD
+WINAPI
+WaitOnAddressTimeoutThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContext;
+    PWAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    LONG Compare;
+    LONG Index;
+
+    PAGED_CODE();
+
+    ThreadContext = (PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT)lpThreadParameter;
+    Context = ThreadContext->Context;
+    Index = ThreadContext->Index;
+    Compare = 0;
+
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+    if (! WaitOnAddress( &Context->Value,
+                         &Compare,
+                         sizeof(Context->Value),
+                         20 )) {
+        Context->LastErrors[Index] = GetLastError();
+        InterlockedIncrement( (PLONG)&Context->TimeoutCount );
+        return 0;
+    }
+
+    InterlockedIncrement( (PLONG)&Context->FailedCount );
+    return 1;
+}
+
+DWORD
+WINAPI
+RtlWaitOnAddressStressThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContext;
+    PWAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+    LONG Compare;
+    LONG Index;
+
+    PAGED_CODE();
+
+    ThreadContext = (PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT)lpThreadParameter;
+    Context = ThreadContext->Context;
+    Index = ThreadContext->Index;
+    Compare = 0;
+
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+    Timeout.QuadPart = -5000LL * 10000;
+    Status = RtlWaitOnAddress( &Context->Value,
+                               &Compare,
+                               sizeof(Context->Value),
+                               &Timeout );
+    Context->Statuses[Index] = Status;
+    if (Status == STATUS_SUCCESS) {
+        InterlockedIncrement( (PLONG)&Context->WakeCount );
+        return 0;
+    }
+
+    InterlockedIncrement( (PLONG)&Context->FailedCount );
+    return 1;
+}
+
+DWORD
+WINAPI
+RtlWaitOnAddressTimeoutThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContext;
+    PWAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+    LONG Compare;
+    LONG Index;
+
+    PAGED_CODE();
+
+    ThreadContext = (PWAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT)lpThreadParameter;
+    Context = ThreadContext->Context;
+    Index = ThreadContext->Index;
+    Compare = 0;
+
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+    Timeout.QuadPart = -20LL * 10000;
+    Status = RtlWaitOnAddress( &Context->Value,
+                               &Compare,
+                               sizeof(Context->Value),
+                               &Timeout );
+    Context->Statuses[Index] = Status;
+
+    if (Status == STATUS_TIMEOUT) {
+        InterlockedIncrement( (PLONG)&Context->TimeoutCount );
+        return 0;
+    }
+
+    InterlockedIncrement( (PLONG)&Context->FailedCount );
+    return 1;
+}
+
+DWORD
+WINAPI
+WaitOnAddressMixedThreadProc (
+    LPVOID lpThreadParameter
+    )
+{
+    PWAIT_ON_ADDRESS_MIXED_THREAD_CONTEXT ThreadContext;
+    PWAIT_ON_ADDRESS_MIXED_CONTEXT Context;
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+    LONG Compare;
+    LONG Index;
+    LONG AddressIndex;
+
+    PAGED_CODE();
+
+    ThreadContext = (PWAIT_ON_ADDRESS_MIXED_THREAD_CONTEXT)lpThreadParameter;
+    Context = ThreadContext->Context;
+    Index = ThreadContext->Index;
+    AddressIndex = ThreadContext->AddressIndex;
+    Compare = 0;
+
+    InterlockedIncrement( (PLONG)&Context->ReadyCount );
+
+    if (ThreadContext->UseRtl) {
+        Timeout.QuadPart = -3000LL * 10000;
+        Status = RtlWaitOnAddress( &Context->Values[AddressIndex],
+                                   &Compare,
+                                   sizeof(Context->Values[AddressIndex]),
+                                   &Timeout );
+        Context->Statuses[Index] = Status;
+        if (Status != STATUS_SUCCESS) {
+            InterlockedIncrement( (PLONG)&Context->FailedCount );
+            return 1;
+        }
+    } else {
+        if (! WaitOnAddress( &Context->Values[AddressIndex],
+                             &Compare,
+                             sizeof(Context->Values[AddressIndex]),
+                             3000 )) {
+            Context->LastErrors[Index] = GetLastError();
+            InterlockedIncrement( (PLONG)&Context->FailedCount );
+            return 1;
+        }
+        Context->Statuses[Index] = STATUS_SUCCESS;
+    }
+
+    InterlockedIncrement( (PLONG)&Context->WakeCounts[AddressIndex] );
+    InterlockedIncrement( (PLONG)&Context->WakeCount );
+    return 0;
+}
+
+BOOLEAN
+WaitOnAddressWaitForCounter (
+    _In_ volatile LONG* Counter,
+    _In_ LONG Expected,
+    _In_ DWORD TimeoutMilliseconds
+    )
+{
+    DWORD Elapsed;
+
+    PAGED_CODE();
+
+    for (Elapsed = 0; Elapsed < TimeoutMilliseconds; Elapsed++) {
+        if (*Counter == Expected) {
+            return TRUE;
+        }
+        Sleep( 1 );
+    }
+
+    return (*Counter == Expected);
+}
+
+BOOLEAN
+AlertByThreadIdStressTest (
+    VOID
+    )
+{
+    ALERT_BY_THREAD_ID_STRESS_CONTEXT Context;
+    ALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT ThreadContexts[ALERT_BY_THREAD_ID_STRESS_THREADS];
+    HANDLE Threads[ALERT_BY_THREAD_ID_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    NTSTATUS Status;
+    LONG Index;
+    LONG CreatedCount = 0;
+    LONG FirstBadIndex = -1;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       AlertByThreadIdStressThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] Alert stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    while (Context.ReadyCount < CreatedCount) {
+        YieldProcessor();
+    }
+
+    for (Index = 0; Index < CreatedCount; Index += 2) {
+        Status = NtAlertThreadByThreadId( (HANDLE)(ULONG_PTR)Context.ThreadIds[Index] );
+        if (! NT_SUCCESS(Status)) {
+            Context.Statuses[Index] = Status;
+            InterlockedIncrement( (PLONG)&Context.AlertFailedCount );
+        }
+    }
+
+    InterlockedExchange( (PLONG)&Context.Start,
+                         1 );
+    Sleep( 20 );
+
+    for (Index = 1; Index < CreatedCount; Index += 2) {
+        Status = NtAlertThreadByThreadId( (HANDLE)(ULONG_PTR)Context.ThreadIds[Index] );
+        if (! NT_SUCCESS(Status)) {
+            Context.Statuses[Index] = Status;
+            InterlockedIncrement( (PLONG)&Context.AlertFailedCount );
+        }
+    }
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        if (Context.Statuses[Index] != STATUS_ALERTED &&
+            FirstBadIndex < 0) {
+            FirstBadIndex = Index;
+        }
+    }
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.WokenCount != CreatedCount ||
+        Context.FailedCount != 0 ||
+        Context.AlertFailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] Alert stress Wait = 0x%08x Ready = %ld Woken = %ld Failed = %ld AlertFailed = %ld FirstBadIndex = %ld FirstBadStatus = 0x%08x\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.WokenCount,
+                Context.FailedCount,
+                Context.AlertFailedCount,
+                FirstBadIndex,
+                FirstBadIndex >= 0 ? Context.Statuses[FirstBadIndex] : STATUS_SUCCESS);
+        for (Index = 0; Index < CreatedCount; Index++) {
+            if (Context.Statuses[Index] != STATUS_ALERTED) {
+                fprintf(stderr,
+                        "[Failed] AlertStressBad I=%ld S=0x%08x TID=%lu\n",
+                        Index,
+                        Context.Statuses[Index],
+                        Context.ThreadIds[Index]);
+            }
+        }
+        goto Cleanup;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] Alert stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Start,
+                         1 );
+    for (Index = 0; Index < CreatedCount; Index++) {
+        if (Context.ThreadIds[Index]) {
+            NtAlertThreadByThreadId( (HANDLE)(ULONG_PTR)Context.ThreadIds[Index] );
+        }
+    }
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+NtWaitForAlertByThreadIdTimeoutStressTest (
+    VOID
+    )
+{
+    ALERT_BY_THREAD_ID_STRESS_CONTEXT Context;
+    ALERT_BY_THREAD_ID_STRESS_THREAD_CONTEXT ThreadContexts[ALERT_BY_THREAD_ID_TIMEOUT_STRESS_THREADS];
+    HANDLE Threads[ALERT_BY_THREAD_ID_TIMEOUT_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    LONG Index;
+    LONG CreatedCount = 0;
+    LONG FirstBadIndex = -1;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       AlertByThreadIdTimeoutStressThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] NtWait timeout stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    while (Context.ReadyCount < CreatedCount) {
+        YieldProcessor();
+    }
+
+    InterlockedExchange( (PLONG)&Context.Start,
+                         1 );
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        if (Context.Statuses[Index] != STATUS_TIMEOUT &&
+            FirstBadIndex < 0) {
+            FirstBadIndex = Index;
+        }
+    }
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.TimeoutCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] NtWait timeout stress Wait = 0x%08x Ready = %ld Timeout = %ld Failed = %ld FirstBadIndex = %ld FirstBadStatus = 0x%08x\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.TimeoutCount,
+                Context.FailedCount,
+                FirstBadIndex,
+                FirstBadIndex >= 0 ? Context.Statuses[FirstBadIndex] : STATUS_SUCCESS);
+        goto Cleanup;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] NtWait timeout stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Start,
+                         1 );
+    for (Index = 0; Index < CreatedCount; Index++) {
+        if (Context.ThreadIds[Index]) {
+            NtAlertThreadByThreadId( (HANDLE)(ULONG_PTR)Context.ThreadIds[Index] );
+        }
+    }
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+WaitOnAddressWakeAllStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_STRESS_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    LONG Index;
+    LONG CreatedCount = 0;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       WaitOnAddressStressThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] WaitOnAddress wake-all stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    while (Context.ReadyCount < CreatedCount) {
+        YieldProcessor();
+    }
+
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    WakeByAddressAll( (PVOID)&Context.Value );
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.WakeCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress wake-all stress Wait = 0x%08x Ready = %ld Wake = %ld Failed = %ld FirstError = %lu Value = %ld\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.WakeCount,
+                Context.FailedCount,
+                Context.LastErrors[0],
+                Context.Value);
+        goto Cleanup;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] WaitOnAddress wake-all stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    WakeByAddressAll( (PVOID)&Context.Value );
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+WaitOnAddressWakeSingleStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_SINGLE_STRESS_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_SINGLE_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    BOOLEAN SingleCompleted;
+    LONG Attempt;
+    LONG Index;
+    LONG CreatedCount = 0;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       WaitOnAddressStressThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] WaitOnAddress wake-single stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    while (Context.ReadyCount < CreatedCount) {
+        YieldProcessor();
+    }
+    Sleep( 20 );
+
+    for (Attempt = 0;
+         Attempt < 10000 && Context.WakeCount < CreatedCount;
+         Attempt++) {
+        WakeByAddressSingle( (PVOID)&Context.Value );
+        if ((Attempt % 64) == 0) {
+            Sleep( 1 );
+        } else {
+            YieldProcessor();
+        }
+    }
+
+    SingleCompleted = (Context.WakeCount == CreatedCount);
+    if (! SingleCompleted) {
+        InterlockedExchange( (PLONG)&Context.Value,
+                             1 );
+        WakeByAddressAll( (PVOID)&Context.Value );
+    }
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    if (! SingleCompleted ||
+        WaitResult != WAIT_OBJECT_0 ||
+        Context.WakeCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress wake-single stress Wait = 0x%08x SingleCompleted = %d Ready = %ld Wake = %ld Failed = %ld Attempts = %ld FirstError = %lu Value = %ld\n",
+                WaitResult,
+                SingleCompleted,
+                Context.ReadyCount,
+                Context.WakeCount,
+                Context.FailedCount,
+                Attempt,
+                Context.LastErrors[0],
+                Context.Value);
+        goto CleanupCloseOnly;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] WaitOnAddress wake-single stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    WakeByAddressAll( (PVOID)&Context.Value );
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+CleanupCloseOnly:
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+WaitOnAddressTimeoutStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_TIMEOUT_STRESS_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_TIMEOUT_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    LONG Index;
+    LONG CreatedCount = 0;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       WaitOnAddressTimeoutThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] WaitOnAddress timeout stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.TimeoutCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress timeout stress Wait = 0x%08x Ready = %ld Timeout = %ld Failed = %ld FirstError = %lu Value = %ld\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.TimeoutCount,
+                Context.FailedCount,
+                Context.LastErrors[0],
+                Context.Value);
+        goto Cleanup;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] WaitOnAddress timeout stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    WakeByAddressAll( (PVOID)&Context.Value );
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+RtlWaitOnAddressWakeAllStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_STRESS_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    LONG Index;
+    LONG CreatedCount = 0;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       RtlWaitOnAddressStressThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] RtlWaitOnAddress stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    while (Context.ReadyCount < CreatedCount) {
+        YieldProcessor();
+    }
+
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    RtlWakeAddressAll( (PVOID)&Context.Value );
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.WakeCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] RtlWaitOnAddress stress Wait = 0x%08x Ready = %ld Wake = %ld Failed = %ld FirstStatus = 0x%08x Value = %ld\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.WakeCount,
+                Context.FailedCount,
+                Context.Statuses[0],
+                Context.Value);
+        goto Cleanup;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] RtlWaitOnAddress wake-all stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    RtlWakeAddressAll( (PVOID)&Context.Value );
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+RtlWaitOnAddressWakeSingleStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_SINGLE_STRESS_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_SINGLE_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    BOOLEAN SingleCompleted;
+    LONG Attempt;
+    LONG Index;
+    LONG CreatedCount = 0;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       RtlWaitOnAddressStressThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] RtlWaitOnAddress wake-single stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    while (Context.ReadyCount < CreatedCount) {
+        YieldProcessor();
+    }
+    Sleep( 20 );
+
+    for (Attempt = 0;
+         Attempt < 10000 && Context.WakeCount < CreatedCount;
+         Attempt++) {
+        RtlWakeAddressSingle( (PVOID)&Context.Value );
+        if ((Attempt % 64) == 0) {
+            Sleep( 1 );
+        } else {
+            YieldProcessor();
+        }
+    }
+
+    SingleCompleted = (Context.WakeCount == CreatedCount);
+    if (! SingleCompleted) {
+        InterlockedExchange( (PLONG)&Context.Value,
+                             1 );
+        RtlWakeAddressAll( (PVOID)&Context.Value );
+    }
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    if (! SingleCompleted ||
+        WaitResult != WAIT_OBJECT_0 ||
+        Context.WakeCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] RtlWaitOnAddress wake-single stress Wait = 0x%08x SingleCompleted = %d Ready = %ld Wake = %ld Failed = %ld Attempts = %ld FirstStatus = 0x%08x Value = %ld\n",
+                WaitResult,
+                SingleCompleted,
+                Context.ReadyCount,
+                Context.WakeCount,
+                Context.FailedCount,
+                Attempt,
+                Context.Statuses[0],
+                Context.Value);
+        goto CleanupCloseOnly;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] RtlWaitOnAddress wake-single stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    RtlWakeAddressAll( (PVOID)&Context.Value );
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+CleanupCloseOnly:
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+RtlWaitOnAddressTimeoutStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_STRESS_CONTEXT Context;
+    WAIT_ON_ADDRESS_STRESS_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_TIMEOUT_STRESS_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_TIMEOUT_STRESS_THREADS] = { NULL, };
+    DWORD WaitResult;
+    LONG Index;
+    LONG CreatedCount = 0;
+    LONG FirstBadIndex = -1;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       RtlWaitOnAddressTimeoutThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] RtlWaitOnAddress timeout stress CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         7000 );
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        if (Context.Statuses[Index] != STATUS_TIMEOUT &&
+            FirstBadIndex < 0) {
+            FirstBadIndex = Index;
+        }
+    }
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.TimeoutCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] RtlWaitOnAddress timeout stress Wait = 0x%08x Ready = %ld Timeout = %ld Failed = %ld FirstBadIndex = %ld FirstBadStatus = 0x%08x Value = %ld\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.TimeoutCount,
+                Context.FailedCount,
+                FirstBadIndex,
+                FirstBadIndex >= 0 ? Context.Statuses[FirstBadIndex] : STATUS_SUCCESS,
+                Context.Value);
+        goto Cleanup;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] RtlWaitOnAddress timeout stress\n\n");
+    return TRUE;
+
+Cleanup:
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    RtlWakeAddressAll( (PVOID)&Context.Value );
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+WaitOnAddressAddressIsolationStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_MIXED_CONTEXT Context;
+    WAIT_ON_ADDRESS_MIXED_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_MIXED_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_MIXED_THREADS] = { NULL, };
+    DWORD WaitResult;
+    LONG AddressIndex;
+    LONG CreatedCount = 0;
+    LONG FirstBadIndex = -1;
+    LONG Index;
+    LONG OtherAddressIndex;
+
+    PAGED_CODE();
+
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        ThreadContexts[Index].Context = &Context;
+        ThreadContexts[Index].Index = Index;
+        ThreadContexts[Index].AddressIndex = Index % WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT;
+        ThreadContexts[Index].UseRtl = (BOOLEAN)((Index & 1) != 0);
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       WaitOnAddressMixedThreadProc,
+                                       &ThreadContexts[Index],
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] WaitOnAddress address-isolation CreateThread[%ld] ErrorCode = %d\n",
+                    Index,
+                    GetLastError());
+            goto Cleanup;
+        }
+        CreatedCount++;
+    }
+
+    while (Context.ReadyCount < CreatedCount) {
+        YieldProcessor();
+    }
+    Sleep( 20 );
+
+    for (AddressIndex = 0;
+         AddressIndex < WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT;
+         AddressIndex++) {
+        for (OtherAddressIndex = AddressIndex + 1;
+             OtherAddressIndex < WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT;
+             OtherAddressIndex++) {
+            if (Context.WakeCounts[OtherAddressIndex] != 0) {
+                fprintf(stderr,
+                        "[Failed] WaitOnAddress address-isolation early wake Address = %ld OtherAddress = %ld OtherWake = %ld\n",
+                        AddressIndex,
+                        OtherAddressIndex,
+                        Context.WakeCounts[OtherAddressIndex]);
+                goto Cleanup;
+            }
+        }
+
+        InterlockedExchange( (PLONG)&Context.Values[AddressIndex],
+                             1 );
+        if ((AddressIndex & 1) == 0) {
+            WakeByAddressAll( (PVOID)&Context.Values[AddressIndex] );
+        } else {
+            RtlWakeAddressAll( (PVOID)&Context.Values[AddressIndex] );
+        }
+
+        if (! WaitOnAddressWaitForCounter( &Context.WakeCounts[AddressIndex],
+                                           WAIT_ON_ADDRESS_MIXED_WAITERS_PER_ADDRESS,
+                                           1000 )) {
+            fprintf(stderr,
+                    "[Failed] WaitOnAddress address-isolation wake Address = %ld Wake = %ld Expected = %ld TotalWake = %ld Failed = %ld\n",
+                    AddressIndex,
+                    Context.WakeCounts[AddressIndex],
+                    (LONG)WAIT_ON_ADDRESS_MIXED_WAITERS_PER_ADDRESS,
+                    Context.WakeCount,
+                    Context.FailedCount);
+            goto Cleanup;
+        }
+    }
+
+    WaitResult = WaitForMultipleObjects( CreatedCount,
+                                         Threads,
+                                         TRUE,
+                                         5000 );
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        if (Context.Statuses[Index] != STATUS_SUCCESS &&
+            FirstBadIndex < 0) {
+            FirstBadIndex = Index;
+        }
+    }
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.WakeCount != CreatedCount ||
+        Context.FailedCount != 0) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress address-isolation Wait = 0x%08x Ready = %ld Wake = %ld Failed = %ld FirstBadIndex = %ld FirstStatus = 0x%08x FirstError = %lu\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.WakeCount,
+                Context.FailedCount,
+                FirstBadIndex,
+                FirstBadIndex >= 0 ? Context.Statuses[FirstBadIndex] : STATUS_SUCCESS,
+                FirstBadIndex >= 0 ? Context.LastErrors[FirstBadIndex] : ERROR_SUCCESS);
+        goto Cleanup;
+    }
+
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("[Success] WaitOnAddress address-isolation stress\n\n");
+    return TRUE;
+
+Cleanup:
+    for (AddressIndex = 0;
+         AddressIndex < WAIT_ON_ADDRESS_MIXED_ADDRESS_COUNT;
+         AddressIndex++) {
+        InterlockedExchange( (PLONG)&Context.Values[AddressIndex],
+                             1 );
+        WakeByAddressAll( (PVOID)&Context.Values[AddressIndex] );
+        RtlWakeAddressAll( (PVOID)&Context.Values[AddressIndex] );
+    }
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+WaitOnAddressRepeatedDurabilityStressTest (
+    VOID
+    )
+{
+    WAIT_ON_ADDRESS_MIXED_CONTEXT Context;
+    WAIT_ON_ADDRESS_MIXED_THREAD_CONTEXT ThreadContexts[WAIT_ON_ADDRESS_DURABILITY_THREADS];
+    HANDLE Threads[WAIT_ON_ADDRESS_DURABILITY_THREADS] = { NULL, };
+    DWORD WaitResult;
+    BOOLEAN SingleCompleted;
+    LONG Attempt;
+    LONG CreatedCount;
+    LONG FirstBadIndex;
+    LONG Index;
+    LONG Round;
+
+    PAGED_CODE();
+
+    for (Round = 0; Round < WAIT_ON_ADDRESS_DURABILITY_ROUNDS; Round++) {
+        RtlZeroMemory( &Context,
+                       sizeof(Context) );
+        RtlZeroMemory( Threads,
+                       sizeof(Threads) );
+        CreatedCount = 0;
+        FirstBadIndex = -1;
+
+        for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+            ThreadContexts[Index].Context = &Context;
+            ThreadContexts[Index].Index = Index;
+            ThreadContexts[Index].AddressIndex = 0;
+            ThreadContexts[Index].UseRtl = (BOOLEAN)(((Round + Index) & 1) != 0);
+            Threads[Index] = CreateThread( NULL,
+                                           0,
+                                           WaitOnAddressMixedThreadProc,
+                                           &ThreadContexts[Index],
+                                           0,
+                                           NULL );
+            if (! Threads[Index]) {
+                fprintf(stderr,
+                        "[Failed] WaitOnAddress durability CreateThread Round = %ld Index = %ld ErrorCode = %d\n",
+                        Round,
+                        Index,
+                        GetLastError());
+                goto CleanupRound;
+            }
+            CreatedCount++;
+        }
+
+        while (Context.ReadyCount < CreatedCount) {
+            YieldProcessor();
+        }
+        Sleep( 20 );
+
+        if ((Round & 1) == 0) {
+            InterlockedExchange( (PLONG)&Context.Values[0],
+                                 1 );
+            if ((Round & 2) == 0) {
+                WakeByAddressAll( (PVOID)&Context.Values[0] );
+            } else {
+                RtlWakeAddressAll( (PVOID)&Context.Values[0] );
+            }
+        } else {
+            for (Attempt = 0;
+                 Attempt < 5000 && Context.WakeCount < CreatedCount;
+                 Attempt++) {
+                if ((Round & 2) == 0) {
+                    WakeByAddressSingle( (PVOID)&Context.Values[0] );
+                } else {
+                    RtlWakeAddressSingle( (PVOID)&Context.Values[0] );
+                }
+                if ((Attempt % 64) == 0) {
+                    Sleep( 1 );
+                } else {
+                    YieldProcessor();
+                }
+            }
+
+            SingleCompleted = (Context.WakeCount == CreatedCount);
+            if (! SingleCompleted) {
+                InterlockedExchange( (PLONG)&Context.Values[0],
+                                     1 );
+                WakeByAddressAll( (PVOID)&Context.Values[0] );
+                RtlWakeAddressAll( (PVOID)&Context.Values[0] );
+            }
+        }
+
+        WaitResult = WaitForMultipleObjects( CreatedCount,
+                                             Threads,
+                                             TRUE,
+                                             5000 );
+
+        for (Index = 0; Index < CreatedCount; Index++) {
+            if (Context.Statuses[Index] != STATUS_SUCCESS &&
+                FirstBadIndex < 0) {
+                FirstBadIndex = Index;
+            }
+        }
+
+        if (WaitResult != WAIT_OBJECT_0 ||
+            Context.WakeCount != CreatedCount ||
+            Context.FailedCount != 0) {
+            fprintf(stderr,
+                    "[Failed] WaitOnAddress durability Round = %ld Wait = 0x%08x Ready = %ld Wake = %ld Failed = %ld FirstBadIndex = %ld FirstStatus = 0x%08x FirstError = %lu Value = %ld\n",
+                    Round,
+                    WaitResult,
+                    Context.ReadyCount,
+                    Context.WakeCount,
+                    Context.FailedCount,
+                    FirstBadIndex,
+                    FirstBadIndex >= 0 ? Context.Statuses[FirstBadIndex] : STATUS_SUCCESS,
+                    FirstBadIndex >= 0 ? Context.LastErrors[FirstBadIndex] : ERROR_SUCCESS,
+                    Context.Values[0]);
+            goto CleanupRound;
+        }
+
+        for (Index = 0; Index < CreatedCount; Index++) {
+            CloseHandle( Threads[Index] );
+            Threads[Index] = NULL;
+        }
+    }
+
+    printf("[Success] WaitOnAddress repeated durability stress Rounds = %ld Threads = %ld\n\n",
+           (LONG)WAIT_ON_ADDRESS_DURABILITY_ROUNDS,
+           (LONG)WAIT_ON_ADDRESS_DURABILITY_THREADS);
+    return TRUE;
+
+CleanupRound:
+    InterlockedExchange( (PLONG)&Context.Values[0],
+                         1 );
+    WakeByAddressAll( (PVOID)&Context.Values[0] );
+    RtlWakeAddressAll( (PVOID)&Context.Values[0] );
+    if (CreatedCount) {
+        WaitForMultipleObjects( CreatedCount,
+                                Threads,
+                                TRUE,
+                                2000 );
+    }
+    for (Index = 0; Index < CreatedCount; Index++) {
+        CloseHandle( Threads[Index] );
+    }
+    return FALSE;
+}
+
+BOOLEAN
+WaitOnAddressSizeMatrixTest (
+    VOID
+    )
+{
+    LARGE_INTEGER Timeout;
+    NTSTATUS Status;
+    UCHAR Value8;
+    UCHAR Compare8;
+    USHORT Value16;
+    USHORT Compare16;
+    ULONG Value32;
+    ULONG Compare32;
+    ULONGLONG Value64;
+    ULONGLONG Compare64;
+
+    PAGED_CODE();
+
+    Timeout.QuadPart = 0;
+
+    Value8 = 1;
+    Compare8 = 0;
+    Status = RtlWaitOnAddress( &Value8,
+                               &Compare8,
+                               sizeof(Value8),
+                               &Timeout );
+    if (Status != STATUS_SUCCESS) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix immediate UCHAR Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Value16 = 1;
+    Compare16 = 0;
+    Status = RtlWaitOnAddress( &Value16,
+                               &Compare16,
+                               sizeof(Value16),
+                               &Timeout );
+    if (Status != STATUS_SUCCESS) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix immediate USHORT Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Value32 = 1;
+    Compare32 = 0;
+    Status = RtlWaitOnAddress( &Value32,
+                               &Compare32,
+                               sizeof(Value32),
+                               &Timeout );
+    if (Status != STATUS_SUCCESS) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix immediate ULONG Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Value64 = 1;
+    Compare64 = 0;
+    Status = RtlWaitOnAddress( &Value64,
+                               &Compare64,
+                               sizeof(Value64),
+                               &Timeout );
+    if (Status != STATUS_SUCCESS) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix immediate ULONGLONG Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Value8 = 0;
+    Compare8 = 0;
+    Status = RtlWaitOnAddress( &Value8,
+                               &Compare8,
+                               sizeof(Value8),
+                               &Timeout );
+    if (Status != STATUS_TIMEOUT) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix timeout UCHAR Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Value16 = 0;
+    Compare16 = 0;
+    Status = RtlWaitOnAddress( &Value16,
+                               &Compare16,
+                               sizeof(Value16),
+                               &Timeout );
+    if (Status != STATUS_TIMEOUT) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix timeout USHORT Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Value32 = 0;
+    Compare32 = 0;
+    Status = RtlWaitOnAddress( &Value32,
+                               &Compare32,
+                               sizeof(Value32),
+                               &Timeout );
+    if (Status != STATUS_TIMEOUT) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix timeout ULONG Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Value64 = 0;
+    Compare64 = 0;
+    Status = RtlWaitOnAddress( &Value64,
+                               &Compare64,
+                               sizeof(Value64),
+                               &Timeout );
+    if (Status != STATUS_TIMEOUT) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix timeout ULONGLONG Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    Status = RtlWaitOnAddress( &Value32,
+                               &Compare32,
+                               3,
+                               &Timeout );
+    if (Status != STATUS_INVALID_PARAMETER) {
+        fprintf(stderr,
+                "[Failed] WaitOnAddress size matrix invalid size Status = 0x%08x\n",
+                Status);
+        return FALSE;
+    }
+
+    if (! WaitOnAddress( &Value8,
+                         &Compare8,
+                         sizeof(Value8),
+                         0 )) {
+        printf("[Success] WaitOnAddress size matrix\n\n");
+        return TRUE;
+    }
+
+    fprintf(stderr,
+            "[Failed] WaitOnAddress size matrix wrapper timeout Value8 = %u Compare8 = %u\n",
+            Value8,
+            Compare8);
+    return FALSE;
+}
+
+BOOLEAN
+WaitOnAddressTest (
+    VOID
+    )
+{
+    ALERT_BY_THREAD_ID_TEST_CONTEXT AlertContext;
+    WAIT_ON_ADDRESS_TEST_CONTEXT Context;
+    HANDLE Thread;
+    HANDLE Threads[3];
+    DWORD ExitCode;
+    DWORD WaitResult;
+    BOOL ExitCodeResult;
+    NTSTATUS Status;
+    LONG Compare;
+    BOOLEAN Result = TRUE;
+    int Index;
+
+    PAGED_CODE();
+
+    printf("WaitOnAddress Test\n");
+
+    printf("Test NtAlertThreadByThreadId/NtWaitForAlertByThreadId\n");
+    RtlZeroMemory( &AlertContext,
+                   sizeof(AlertContext) );
+    Thread = CreateThread( NULL,
+                           0,
+                           AlertByThreadIdTestThreadProc,
+                           &AlertContext,
+                           0,
+                           NULL );
+    if (! Thread) {
+        fprintf(stderr, "[Failed] CreateThread(Alert) ErrorCode = %d\n", GetLastError());
+        return FALSE;
+    }
+
+    while (! AlertContext.Ready) {
+        YieldProcessor();
+    }
+
+    Status = NtAlertThreadByThreadId( (HANDLE)(ULONG_PTR)AlertContext.ThreadId );
+    WaitResult = WaitForSingleObject( Thread,
+                                      2000 );
+    ExitCode = (DWORD)-1;
+    ExitCodeResult = GetExitCodeThread( Thread,
+                                        &ExitCode );
+
+    if (! NT_SUCCESS(Status) ||
+        WaitResult != WAIT_OBJECT_0 ||
+        ! ExitCodeResult ||
+        ExitCode != 0 ||
+        AlertContext.Woken != 1) {
+        fprintf(stderr,
+                "[Failed] AlertBasic A=0x%08x W=0x%08x X=%d EC=%lu R=%ld WK=%ld WS=0x%08x TID=%lu\n",
+                Status,
+                WaitResult,
+                ExitCodeResult,
+                ExitCode,
+                AlertContext.Ready,
+                AlertContext.Woken,
+                AlertContext.WaitStatus,
+                AlertContext.ThreadId);
+        Result = FALSE;
+    } else {
+        printf("[Success] Test NtAlertThreadByThreadId/NtWaitForAlertByThreadId\n\n");
+    }
+    CloseHandle( Thread );
+
+    printf("Test WaitOnAddress immediate success\n");
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+    Context.Value = 1;
+    Compare = 0;
+    if (WaitOnAddress( &Context.Value,
+                       &Compare,
+                       sizeof(Context.Value),
+                       1000 )) {
+        printf("[Success] Test WaitOnAddress immediate success\n\n");
+    } else {
+        fprintf(stderr,
+                "[Failed] Test WaitOnAddress immediate success ErrorCode = %d Value = %ld Compare = %ld\n",
+                GetLastError(),
+                Context.Value,
+                Compare);
+        Result = FALSE;
+    }
+
+    printf("Test WaitOnAddress timeout\n");
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+    Compare = 0;
+    if (! WaitOnAddress( &Context.Value,
+                         &Compare,
+                         sizeof(Context.Value),
+                         10 )) {
+        printf("[Success] Test WaitOnAddress timeout\n\n");
+    } else {
+        fprintf(stderr,
+                "[Failed] Test WaitOnAddress timeout ErrorCode = %d Value = %ld Compare = %ld\n",
+                GetLastError(),
+                Context.Value,
+                Compare);
+        Result = FALSE;
+    }
+
+    printf("Test WakeByAddressSingle\n");
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+    Thread = CreateThread( NULL,
+                           0,
+                           WaitOnAddressTestThreadProc,
+                           &Context,
+                           0,
+                           NULL );
+    if (! Thread) {
+        fprintf(stderr, "[Failed] CreateThread(Single) ErrorCode = %d\n", GetLastError());
+        return FALSE;
+    }
+
+    while (Context.ReadyCount < 1) {
+        YieldProcessor();
+    }
+
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    WakeByAddressSingle( (PVOID)&Context.Value );
+
+    WaitResult = WaitForSingleObject( Thread,
+                                      2000 );
+    ExitCode = (DWORD)-1;
+    ExitCodeResult = GetExitCodeThread( Thread,
+                                        &ExitCode );
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        ! ExitCodeResult ||
+        ExitCode != 0 ||
+        Context.WakeCount != 1) {
+        fprintf(stderr,
+                "[Failed] Test WakeByAddressSingle Wait = 0x%08x ExitCodeResult = %d ExitCode = %d ReadyCount = %ld WakeCount = %ld Value = %ld\n",
+                WaitResult,
+                ExitCodeResult,
+                ExitCode,
+                Context.ReadyCount,
+                Context.WakeCount,
+                Context.Value);
+        Result = FALSE;
+    } else {
+        printf("[Success] Test WakeByAddressSingle\n\n");
+    }
+    CloseHandle( Thread );
+
+    printf("Test WakeByAddressAll\n");
+    RtlZeroMemory( &Context,
+                   sizeof(Context) );
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        Threads[Index] = CreateThread( NULL,
+                                       0,
+                                       WaitOnAddressTestThreadProc,
+                                       &Context,
+                                       0,
+                                       NULL );
+        if (! Threads[Index]) {
+            fprintf(stderr,
+                    "[Failed] CreateThread(All)[%d] ErrorCode = %d ReadyCount = %ld\n",
+                    Index,
+                    GetLastError(),
+                    Context.ReadyCount);
+            return FALSE;
+        }
+    }
+
+    while (Context.ReadyCount < RTL_NUMBER_OF(Threads)) {
+        YieldProcessor();
+    }
+
+    InterlockedExchange( (PLONG)&Context.Value,
+                         1 );
+    WakeByAddressAll( (PVOID)&Context.Value );
+
+    WaitResult = WaitForMultipleObjects( RTL_NUMBER_OF(Threads),
+                                         Threads,
+                                         TRUE,
+                                         2000 );
+
+    if (WaitResult != WAIT_OBJECT_0 ||
+        Context.WakeCount != RTL_NUMBER_OF(Threads)) {
+        fprintf(stderr,
+                "[Failed] Test WakeByAddressAll Wait = 0x%08x ReadyCount = %ld WakeCount = %ld Value = %ld ExpectedWakeCount = %llu\n",
+                WaitResult,
+                Context.ReadyCount,
+                Context.WakeCount,
+                Context.Value,
+                (ULONGLONG)RTL_NUMBER_OF(Threads));
+        Result = FALSE;
+    } else {
+        printf("[Success] Test WakeByAddressAll\n\n");
+    }
+
+    for (Index = 0; Index < RTL_NUMBER_OF(Threads); Index++) {
+        CloseHandle( Threads[Index] );
+    }
+
+    printf("Test NtAlertThreadByThreadId/NtWaitForAlertByThreadId stress\n");
+    if (! AlertByThreadIdStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test NtWaitForAlertByThreadId timeout stress\n");
+    if (! NtWaitForAlertByThreadIdTimeoutStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test WaitOnAddress WakeByAddressAll stress\n");
+    if (! WaitOnAddressWakeAllStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test WaitOnAddress WakeByAddressSingle stress\n");
+    if (! WaitOnAddressWakeSingleStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test WaitOnAddress timeout stress\n");
+    if (! WaitOnAddressTimeoutStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test RtlWaitOnAddress/RtlWakeAddressAll stress\n");
+    if (! RtlWaitOnAddressWakeAllStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test RtlWaitOnAddress/RtlWakeAddressSingle stress\n");
+    if (! RtlWaitOnAddressWakeSingleStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test RtlWaitOnAddress timeout stress\n");
+    if (! RtlWaitOnAddressTimeoutStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test WaitOnAddress address-isolation stress\n");
+    if (! WaitOnAddressAddressIsolationStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test WaitOnAddress repeated durability stress\n");
+    if (! WaitOnAddressRepeatedDurabilityStressTest()) {
+        Result = FALSE;
+    }
+
+    printf("Test WaitOnAddress size matrix\n");
+    if (! WaitOnAddressSizeMatrixTest()) {
+        Result = FALSE;
+    }
+
+    return Result;
 }


### PR DESCRIPTION
## Summary
- implement native alert-by-thread-id and wait-on-address support through NTDLL/RTL/Kernel32 layers
- expand synchronization stress coverage and harden thread/FLS cleanup paths
- add docs for runtime architecture, loader, synchronization, API support, and testing
- add NuGet packaging plus GitHub Release workflows modeled after crtsys, including package and prebuilt bundle validation

## Validation
- built LDK x86/x64 Debug/Release via `scripts/nuget/Build-LdkNuGetLibs.ps1`
- packed `ldk.0.7.5.nupkg` without NuGet warnings
- generated release assets: `.nupkg`, prebuilt zip, SHA256SUMS
- verified NuGet-installed CMake driver consumers for x86 Release and x64 Release
- verified prebuilt release CMake driver consumers for x86 Release, x64 Release, and x64 Debug
- ran PowerShell parser checks, XML parser checks, trailing-whitespace checks, and `git diff --check`