### PR TITLE
Improve file information API coverage

### DIFF
--- a/docs/api/file-and-handles.md
+++ b/docs/api/file-and-handles.md
@@ -33,6 +33,8 @@ attribute helpers are backed by native file information queries and setters.
 `SetFileInformationByHandle` currently supports:
 
 - `FileBasicInfo`
+- `FileRenameInfo`
+- `FileRenameInfoEx`
 - `FileAllocationInfo`
 - `FileEndOfFileInfo`
 - `FileDispositionInfo`
@@ -55,9 +57,12 @@ without treating every unknown value as a caller bug.
 names where the kernel object can be resolved.
 
 `FindFirstFileW`, `FindFirstFileExW`, `FindNextFileW`, and `FindClose` cover the
-normal wildcard enumeration path. `FIND_FIRST_EX_CASE_SENSITIVE` is not
-implemented because it needs case-sensitive path policy support across the
-directory open and match path.
+normal wildcard enumeration path. `FindFirstFileExW` accepts the documented
+`FIND_FIRST_EX_CASE_SENSITIVE`, `FIND_FIRST_EX_LARGE_FETCH`, and
+`FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY` flags and rejects unknown flag bits with
+`ERROR_INVALID_PARAMETER`. The flags are routed through the native directory
+query path; LDK does not add a stricter case policy than the underlying file
+system namespace provides.
 
 `CreateHardLinkW` and `CreateSymbolicLinkW` are implemented for the tested file
 scenarios. Symbolic-link tests verify the reparse tag path and target reads.
@@ -89,6 +94,6 @@ completion semantics rather than a synchronous approximation.
 ## Tests
 
 `FileTest` covers the common file path, copy, move, hard-link, symbolic-link,
-final-path, temp-path, temp-file, `FileNameInfo`, `FileAllocationInfo`, and
-disposition paths. Runtime validation still requires loading `LdkTest.sys` in
-a driver test VM.
+final-path, temp-path, temp-file, `FileNameInfo`, `FindFirstFileExW` flags,
+`FileAllocationInfo`, rename, and disposition paths. Runtime validation still
+requires loading `LdkTest.sys` in a driver test VM.

--- a/include/Ldk/winbase.h
+++ b/include/Ldk/winbase.h
@@ -152,6 +152,12 @@ EXTERN_C_START
 #define FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE 0x00000010
 #endif
 
+#ifndef FILE_RENAME_FLAG_REPLACE_IF_EXISTS
+#define FILE_RENAME_FLAG_REPLACE_IF_EXISTS 0x00000001
+#define FILE_RENAME_FLAG_POSIX_SEMANTICS 0x00000002
+#define FILE_RENAME_FLAG_SUPPRESS_PIN_STATE_INHERITANCE 0x00000004
+#endif
+
 #ifndef SYMBOLIC_LINK_FLAG_DIRECTORY
 #define SYMBOLIC_LINK_FLAG_DIRECTORY 0x1
 #endif
@@ -185,6 +191,23 @@ typedef struct _FILE_DISPOSITION_INFO {
     BOOLEAN DeleteFile;
 } FILE_DISPOSITION_INFO, *PFILE_DISPOSITION_INFO;
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4201)
+#endif
+typedef struct _FILE_RENAME_INFO {
+    union {
+        BOOLEAN ReplaceIfExists;
+        DWORD Flags;
+    } DUMMYUNIONNAME;
+    HANDLE RootDirectory;
+    DWORD FileNameLength;
+    WCHAR FileName[1];
+} FILE_RENAME_INFO, *PFILE_RENAME_INFO;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 typedef struct _FILE_ALLOCATION_INFO {
     LARGE_INTEGER AllocationSize;
 } FILE_ALLOCATION_INFO, *PFILE_ALLOCATION_INFO;
@@ -216,6 +239,9 @@ typedef struct _FILE_ID_INFO {
 #ifndef FileNameInfo
 #define FileNameInfo ((FILE_INFO_BY_HANDLE_CLASS)2)
 #endif
+#ifndef FileRenameInfo
+#define FileRenameInfo ((FILE_INFO_BY_HANDLE_CLASS)3)
+#endif
 #ifndef FileDispositionInfo
 #define FileDispositionInfo ((FILE_INFO_BY_HANDLE_CLASS)4)
 #endif
@@ -233,6 +259,9 @@ typedef struct _FILE_ID_INFO {
 #endif
 #ifndef FileDispositionInfoEx
 #define FileDispositionInfoEx ((FILE_INFO_BY_HANDLE_CLASS)21)
+#endif
+#ifndef FileRenameInfoEx
+#define FileRenameInfoEx ((FILE_INFO_BY_HANDLE_CLASS)22)
 #endif
 
 #define LDK_HAS_WINBASE_FILE_INFO_TYPES 1

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -2820,7 +2820,9 @@ SetFileInformationByHandle (
         RtlZeroMemory( NativeRenameInfo,
                        NativeRenameInfoSize );
         if (FileInformationClass == FileRenameInfoEx) {
-            NativeRenameInfo->Flags = RenameInfo->Flags;
+            RtlCopyMemory( NativeRenameInfo,
+                           &RenameInfo->Flags,
+                           sizeof(RenameInfo->Flags) );
             NativeInformationClass = LDK_FILE_RENAME_INFORMATION_EX_CLASS;
         } else {
             NativeRenameInfo->ReplaceIfExists = RenameInfo->ReplaceIfExists;

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -22,6 +22,20 @@ LdkpQueryFullFileAttributes (
     );
 
 #define LDK_FIND_HANDLE_MAGIC 0x464B444Cu
+#ifdef FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY
+#define LDK_FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY
+#else
+#define LDK_FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY 0
+#endif
+#define LDK_FIND_FIRST_EX_SUPPORTED_FLAGS \
+    (FIND_FIRST_EX_CASE_SENSITIVE | \
+     FIND_FIRST_EX_LARGE_FETCH | \
+     LDK_FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY)
+#define LDK_FILE_RENAME_INFO_EX_SUPPORTED_FLAGS \
+    (FILE_RENAME_FLAG_REPLACE_IF_EXISTS | \
+     FILE_RENAME_FLAG_POSIX_SEMANTICS | \
+     FILE_RENAME_FLAG_SUPPRESS_PIN_STATE_INHERITANCE)
+#define LDK_FILE_RENAME_INFORMATION_EX_CLASS ((FILE_INFORMATION_CLASS)65)
 
 typedef union _LDK_FIND_QUERY_BUFFER {
     FILE_BOTH_DIR_INFORMATION Alignment;
@@ -2704,6 +2718,143 @@ SetFileInformationByHandle (
         return FALSE;
     }
 
+    if (FileInformationClass == FileRenameInfo ||
+        FileInformationClass == FileRenameInfoEx) {
+        PFILE_RENAME_INFO RenameInfo;
+        PFILE_RENAME_INFORMATION NativeRenameInfo;
+        FILE_INFORMATION_CLASS NativeInformationClass;
+        UNICODE_STRING RenameFileName;
+        UNICODE_STRING NtRenameFileName;
+        RTL_RELATIVE_NAME_U RelativeName;
+        PUNICODE_STRING NativeFileName;
+        HANDLE RootDirectory;
+        PWSTR NullTerminatedName;
+        PVOID FreeNtBuffer;
+        ULONG MinimumSize;
+        ULONG NativeRenameInfoSize;
+
+        MinimumSize = FIELD_OFFSET(FILE_RENAME_INFO, FileName);
+        if (dwBufferSize < MinimumSize) {
+            SetLastError( ERROR_INSUFFICIENT_BUFFER );
+            return FALSE;
+        }
+
+        RenameInfo = (PFILE_RENAME_INFO)lpFileInformation;
+        if (RenameInfo->FileNameLength == 0 ||
+            RenameInfo->FileNameLength > MAXUSHORT ||
+            (RenameInfo->FileNameLength & (sizeof(WCHAR) - 1)) != 0) {
+            SetLastError( ERROR_INVALID_PARAMETER );
+            return FALSE;
+        }
+
+        if (RenameInfo->FileNameLength > dwBufferSize - MinimumSize) {
+            SetLastError( ERROR_INSUFFICIENT_BUFFER );
+            return FALSE;
+        }
+
+        if (FileInformationClass == FileRenameInfoEx &&
+            (RenameInfo->Flags & ~LDK_FILE_RENAME_INFO_EX_SUPPORTED_FLAGS) != 0) {
+            SetLastError( ERROR_INVALID_PARAMETER );
+            return FALSE;
+        }
+
+        RenameFileName.Length = (USHORT)RenameInfo->FileNameLength;
+        RenameFileName.MaximumLength = RenameFileName.Length;
+        RenameFileName.Buffer = RenameInfo->FileName;
+        NativeFileName = &RenameFileName;
+        RootDirectory = RenameInfo->RootDirectory;
+        FreeNtBuffer = NULL;
+
+        if (RootDirectory == NULL) {
+            NullTerminatedName = RtlAllocateHeap( RtlProcessHeap(),
+                                                 MAKE_TAG( TMP_TAG ),
+                                                 RenameInfo->FileNameLength + sizeof(UNICODE_NULL) );
+            if (NullTerminatedName == NULL) {
+                LdkSetLastNTError( STATUS_NO_MEMORY );
+                return FALSE;
+            }
+
+            RtlCopyMemory( NullTerminatedName,
+                           RenameInfo->FileName,
+                           RenameInfo->FileNameLength );
+            NullTerminatedName[RenameInfo->FileNameLength / sizeof(WCHAR)] = UNICODE_NULL;
+
+            if (! RtlDosPathNameToNtPathName_U( NullTerminatedName,
+                                                &NtRenameFileName,
+                                                NULL,
+                                                &RelativeName )) {
+                RtlFreeHeap( RtlProcessHeap(),
+                             0,
+                             NullTerminatedName );
+                SetLastError( ERROR_PATH_NOT_FOUND );
+                return FALSE;
+            }
+
+            RtlFreeHeap( RtlProcessHeap(),
+                         0,
+                         NullTerminatedName );
+            FreeNtBuffer = NtRenameFileName.Buffer;
+            if (RelativeName.RelativeName.Length) {
+                NativeFileName = (PUNICODE_STRING)&RelativeName.RelativeName;
+                RootDirectory = RelativeName.ContainingDirectory;
+            } else {
+                NativeFileName = &NtRenameFileName;
+            }
+        }
+
+        NativeRenameInfoSize = FIELD_OFFSET(FILE_RENAME_INFORMATION, FileName) +
+                               NativeFileName->Length;
+        NativeRenameInfo = RtlAllocateHeap( RtlProcessHeap(),
+                                            MAKE_TAG( TMP_TAG ),
+                                            NativeRenameInfoSize );
+        if (NativeRenameInfo == NULL) {
+            if (FreeNtBuffer != NULL) {
+                RtlFreeHeap( RtlProcessHeap(),
+                             0,
+                             FreeNtBuffer );
+            }
+            LdkSetLastNTError( STATUS_NO_MEMORY );
+            return FALSE;
+        }
+
+        RtlZeroMemory( NativeRenameInfo,
+                       NativeRenameInfoSize );
+        if (FileInformationClass == FileRenameInfoEx) {
+            NativeRenameInfo->Flags = RenameInfo->Flags;
+            NativeInformationClass = LDK_FILE_RENAME_INFORMATION_EX_CLASS;
+        } else {
+            NativeRenameInfo->ReplaceIfExists = RenameInfo->ReplaceIfExists;
+            NativeInformationClass = FileRenameInformation;
+        }
+        NativeRenameInfo->RootDirectory = RootDirectory;
+        NativeRenameInfo->FileNameLength = NativeFileName->Length;
+        RtlCopyMemory( NativeRenameInfo->FileName,
+                       NativeFileName->Buffer,
+                       NativeFileName->Length );
+
+        Status = ZwSetInformationFile( hFile,
+                                       &IoStatus,
+                                       NativeRenameInfo,
+                                       NativeRenameInfoSize,
+                                       NativeInformationClass );
+
+        RtlFreeHeap( RtlProcessHeap(),
+                     0,
+                     NativeRenameInfo );
+        if (FreeNtBuffer != NULL) {
+            RtlFreeHeap( RtlProcessHeap(),
+                         0,
+                         FreeNtBuffer );
+        }
+
+        if (NT_SUCCESS(Status)) {
+            return TRUE;
+        }
+
+        LdkSetLastNTError( Status );
+        return FALSE;
+    }
+
     if (FileInformationClass == FileBasicInfo) {
         PFILE_BASIC_INFO BasicInfo;
         FILE_BASIC_INFORMATION NativeBasicInfo;
@@ -3272,9 +3423,8 @@ FindFirstFileExW (
         return INVALID_HANDLE_VALUE;
     }
 
-    if (dwAdditionalFlags & FIND_FIRST_EX_CASE_SENSITIVE) {
-        LDK_DIAGNOSTIC_BREAK();
-        LdkSetLastNTError( STATUS_NOT_IMPLEMENTED );
+    if ((dwAdditionalFlags & ~LDK_FIND_FIRST_EX_SUPPORTED_FLAGS) != 0) {
+        SetLastError( ERROR_INVALID_PARAMETER );
         return INVALID_HANDLE_VALUE;
     }
 

--- a/test/kernel32/file.c
+++ b/test/kernel32/file.c
@@ -273,6 +273,54 @@ FileTest (
     }
     printf("[Success] Test CreateHardLinkW(Test.tmp, TestHardLink.tmp)\n\n");
 
+    printf("Test FindFirstFileExW flags\n");
+    WIN32_FIND_DATAW FindFlagsData;
+    DWORD FindFirstFlags = FIND_FIRST_EX_CASE_SENSITIVE | FIND_FIRST_EX_LARGE_FETCH;
+#ifdef FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY
+    FindFirstFlags |= FIND_FIRST_EX_ON_DISK_ENTRIES_ONLY;
+#endif
+    HANDLE hFindFlags = FindFirstFileExW( L"Test.tmp",
+                                          FindExInfoBasic,
+                                          &FindFlagsData,
+                                          FindExSearchNameMatch,
+                                          NULL,
+                                          FindFirstFlags );
+    if (hFindFlags == INVALID_HANDLE_VALUE ||
+        wcscmp( FindFlagsData.cFileName,
+                L"Test.tmp" ) != 0) {
+        fprintf(stderr,
+                "[Failed] FindFirstFileExW supported flags ErrorCode = %d\n",
+                GetLastError());
+        if (hFindFlags != INVALID_HANDLE_VALUE) {
+            FindClose( hFindFlags );
+        }
+        printf("[Failed] Test FindFirstFileExW flags\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    FindClose( hFindFlags );
+
+    SetLastError( ERROR_SUCCESS );
+    hFindFlags = FindFirstFileExW( L"Test.tmp",
+                                   FindExInfoBasic,
+                                   &FindFlagsData,
+                                   FindExSearchNameMatch,
+                                   NULL,
+                                   0x80000000u );
+    if (hFindFlags != INVALID_HANDLE_VALUE ||
+        GetLastError() != ERROR_INVALID_PARAMETER) {
+        fprintf(stderr,
+                "[Failed] FindFirstFileExW invalid flags ErrorCode = %d\n",
+                GetLastError());
+        if (hFindFlags != INVALID_HANDLE_VALUE) {
+            FindClose( hFindFlags );
+        }
+        printf("[Failed] Test FindFirstFileExW flags\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    printf("[Success] Test FindFirstFileExW flags\n\n");
+
     printf("Test CreateSymbolicLinkW(TestSymlink.tmp, Test.tmp)\n");
     DeleteFileW( L"TestSymlink.tmp" );
     rv = CreateSymbolicLinkW( L"TestSymlink.tmp",
@@ -543,6 +591,135 @@ AfterSymlinkTest:
     }
     printf("[Success] Test SetFileInformationByHandle(FileAllocationInfo)\n\n");
 
+    printf("Test SetFileInformationByHandle(FileRenameInfo)\n");
+    DeleteFileW( L"TestRenameSource.tmp" );
+    DeleteFileW( L"TestRenameTarget.tmp" );
+    hFile = CreateFileW( L"TestRenameSource.tmp",
+                         GENERIC_READ | GENERIC_WRITE | DELETE,
+                         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                         NULL,
+                         CREATE_ALWAYS,
+                         FILE_ATTRIBUTE_NORMAL,
+                         NULL );
+    if (hFile == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileRenameInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    WCHAR RenameTargetPath[MAX_PATH];
+    DWORD RenameTargetPathLength = GetFullPathNameW( L"TestRenameTarget.tmp",
+                                                     RTL_NUMBER_OF(RenameTargetPath),
+                                                     RenameTargetPath,
+                                                     NULL );
+    if (RenameTargetPathLength == 0 ||
+        RenameTargetPathLength >= RTL_NUMBER_OF(RenameTargetPath)) {
+        fprintf(stderr, "[Failed] GetFullPathNameW(TestRenameTarget.tmp) ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test SetFileInformationByHandle(FileRenameInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    UCHAR RenameInfoBuffer[FIELD_OFFSET(FILE_RENAME_INFO, FileName) + MAX_PATH * sizeof(WCHAR)];
+    PFILE_RENAME_INFO RenameInfo = (PFILE_RENAME_INFO)RenameInfoBuffer;
+    RtlZeroMemory( RenameInfoBuffer,
+                   sizeof(RenameInfoBuffer) );
+    RenameInfo->ReplaceIfExists = FALSE;
+    RenameInfo->RootDirectory = NULL;
+    RenameInfo->FileNameLength = RenameTargetPathLength * sizeof(WCHAR);
+    RtlCopyMemory( RenameInfo->FileName,
+                   RenameTargetPath,
+                   RenameInfo->FileNameLength );
+    rv = SetFileInformationByHandle( hFile,
+                                     FileRenameInfo,
+                                     RenameInfo,
+                                     FIELD_OFFSET(FILE_RENAME_INFO, FileName) +
+                                     RenameInfo->FileNameLength );
+    CloseHandle( hFile );
+    if (!rv ||
+        GetFileAttributesW( L"TestRenameSource.tmp" ) != INVALID_FILE_ATTRIBUTES ||
+        GetFileAttributesW( L"TestRenameTarget.tmp" ) == INVALID_FILE_ATTRIBUTES) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileRenameInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    printf("[Success] Test SetFileInformationByHandle(FileRenameInfo)\n\n");
+
+    printf("Test SetFileInformationByHandle(FileRenameInfoEx)\n");
+    DeleteFileW( L"TestRenameExSource.tmp" );
+    DeleteFileW( L"TestRenameExTarget.tmp" );
+    hFile = CreateFileW( L"TestRenameExSource.tmp",
+                         GENERIC_READ | GENERIC_WRITE | DELETE,
+                         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                         NULL,
+                         CREATE_ALWAYS,
+                         FILE_ATTRIBUTE_NORMAL,
+                         NULL );
+    if (hFile == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileRenameInfoEx)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    HANDLE hRenameTarget = CreateFileW( L"TestRenameExTarget.tmp",
+                                        GENERIC_READ | GENERIC_WRITE,
+                                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                        NULL,
+                                        CREATE_ALWAYS,
+                                        FILE_ATTRIBUTE_NORMAL,
+                                        NULL );
+    if (hRenameTarget == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "[Failed] Create target ErrorCode = %d\n", GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test SetFileInformationByHandle(FileRenameInfoEx)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    CloseHandle( hRenameTarget );
+
+    RenameTargetPathLength = GetFullPathNameW( L"TestRenameExTarget.tmp",
+                                               RTL_NUMBER_OF(RenameTargetPath),
+                                               RenameTargetPath,
+                                               NULL );
+    if (RenameTargetPathLength == 0 ||
+        RenameTargetPathLength >= RTL_NUMBER_OF(RenameTargetPath)) {
+        fprintf(stderr, "[Failed] GetFullPathNameW(TestRenameExTarget.tmp) ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test SetFileInformationByHandle(FileRenameInfoEx)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    RtlZeroMemory( RenameInfoBuffer,
+                   sizeof(RenameInfoBuffer) );
+    RenameInfo->Flags = FILE_RENAME_FLAG_REPLACE_IF_EXISTS;
+    RenameInfo->RootDirectory = NULL;
+    RenameInfo->FileNameLength = RenameTargetPathLength * sizeof(WCHAR);
+    RtlCopyMemory( RenameInfo->FileName,
+                   RenameTargetPath,
+                   RenameInfo->FileNameLength );
+    rv = SetFileInformationByHandle( hFile,
+                                     FileRenameInfoEx,
+                                     RenameInfo,
+                                     FIELD_OFFSET(FILE_RENAME_INFO, FileName) +
+                                     RenameInfo->FileNameLength );
+    CloseHandle( hFile );
+    if (!rv ||
+        GetFileAttributesW( L"TestRenameExSource.tmp" ) != INVALID_FILE_ATTRIBUTES ||
+        GetFileAttributesW( L"TestRenameExTarget.tmp" ) == INVALID_FILE_ATTRIBUTES) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileRenameInfoEx)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    printf("[Success] Test SetFileInformationByHandle(FileRenameInfoEx)\n\n");
+
     printf("Test SetFileInformationByHandle(FileDispositionInfoEx)\n");
     DeleteFileW( L"TestDisposition.tmp" );
     hFile = CreateFileW( L"TestDisposition.tmp",
@@ -592,6 +769,10 @@ AfterSymlinkTest:
 
 DeleteTest:
     DeleteFileW( L"TestAllocation.tmp" );
+    DeleteFileW( L"TestRenameSource.tmp" );
+    DeleteFileW( L"TestRenameTarget.tmp" );
+    DeleteFileW( L"TestRenameExSource.tmp" );
+    DeleteFileW( L"TestRenameExTarget.tmp" );
     DeleteFileW( L"TestDisposition.tmp" );
     DeleteFileW( L"TestMoved.tmp" );
     DeleteFileW( L"TestCopy.tmp" );


### PR DESCRIPTION
## Summary

- Add SDK-compatible `FILE_RENAME_INFO` definitions and rename flags to the LDK WinBase surface.
- Implement `SetFileInformationByHandle` support for `FileRenameInfo` and `FileRenameInfoEx` through native file rename information.
- Accept documented `FindFirstFileExW` additional flags and reject unknown flag bits with `ERROR_INVALID_PARAMETER`.
- Extend `FileTest` coverage and update the file API documentation.

## Validation

- `./build.bat . x64 Debug`
- Built `LdkTest.sys`: `D:\projects\ldk\artifacts\build\ldktest-x64\Debug\LdkTest.sys`
- Ran native Win32 baseline full suite: `LdkWin32ApiTest.exe`
- Loaded and unloaded in Win11KD VM:
  - `sc start LdkTestFileApi215232` -> `start_rc=0`, service `RUNNING`
  - `sc stop LdkTestFileApi215232` -> `stop_rc=0`
  - `sc delete LdkTestFileApi215232` -> `delete_rc=0`
  - VMware Tools remained `running`

VM logs:

- `D:\VMs\Win11KD\codex-fileapi-215232-run.log`
- `D:\VMs\Win11KD\codex-fileapi-215232-cleanup.log`