### PR TITLE
Add fixed file information query classes

### DIFF
--- a/docs/api/file-and-handles.md
+++ b/docs/api/file-and-handles.md
@@ -27,7 +27,9 @@ attribute helpers are backed by native file information queries and setters.
 - `FileBasicInfo`
 - `FileStandardInfo`
 - `FileNameInfo`
+- `FileCompressionInfo`
 - `FileAttributeTagInfo`
+- `FileAlignmentInfo`
 - `FileIdInfo`
 
 `SetFileInformationByHandle` currently supports:
@@ -95,5 +97,6 @@ completion semantics rather than a synchronous approximation.
 
 `FileTest` covers the common file path, copy, move, hard-link, symbolic-link,
 final-path, temp-path, temp-file, `FileNameInfo`, `FindFirstFileExW` flags,
-`FileAllocationInfo`, rename, and disposition paths. Runtime validation still
-requires loading `LdkTest.sys` in a driver test VM.
+selected `GetFileInformationByHandleEx` query classes, `FileAllocationInfo`,
+rename, and disposition paths. Runtime validation still requires loading
+`LdkTest.sys` in a driver test VM.

--- a/include/Ldk/winbase.h
+++ b/include/Ldk/winbase.h
@@ -220,6 +220,19 @@ typedef struct _FILE_END_OF_FILE_INFO {
     LARGE_INTEGER EndOfFile;
 } FILE_END_OF_FILE_INFO, *PFILE_END_OF_FILE_INFO;
 
+#ifndef COMPRESSION_FORMAT_NONE
+#define COMPRESSION_FORMAT_NONE 0x0000
+#endif
+
+typedef struct _FILE_COMPRESSION_INFO {
+    LARGE_INTEGER CompressedFileSize;
+    WORD CompressionFormat;
+    UCHAR CompressionUnitShift;
+    UCHAR ChunkShift;
+    UCHAR ClusterShift;
+    UCHAR Reserved[3];
+} FILE_COMPRESSION_INFO, *PFILE_COMPRESSION_INFO;
+
 typedef struct _FILE_ATTRIBUTE_TAG_INFO {
     DWORD FileAttributes;
     DWORD ReparseTag;
@@ -229,6 +242,10 @@ typedef struct _FILE_ID_INFO {
     ULONGLONG VolumeSerialNumber;
     FILE_ID_128 FileId;
 } FILE_ID_INFO, *PFILE_ID_INFO;
+
+typedef struct _FILE_ALIGNMENT_INFO {
+    ULONG AlignmentRequirement;
+} FILE_ALIGNMENT_INFO, *PFILE_ALIGNMENT_INFO;
 
 #ifndef FileBasicInfo
 #define FileBasicInfo ((FILE_INFO_BY_HANDLE_CLASS)0)
@@ -251,8 +268,14 @@ typedef struct _FILE_ID_INFO {
 #ifndef FileEndOfFileInfo
 #define FileEndOfFileInfo ((FILE_INFO_BY_HANDLE_CLASS)6)
 #endif
+#ifndef FileCompressionInfo
+#define FileCompressionInfo ((FILE_INFO_BY_HANDLE_CLASS)8)
+#endif
 #ifndef FileAttributeTagInfo
 #define FileAttributeTagInfo ((FILE_INFO_BY_HANDLE_CLASS)9)
+#endif
+#ifndef FileAlignmentInfo
+#define FileAlignmentInfo ((FILE_INFO_BY_HANDLE_CLASS)17)
 #endif
 #ifndef FileIdInfo
 #define FileIdInfo ((FILE_INFO_BY_HANDLE_CLASS)18)

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -2602,6 +2602,65 @@ GetFileInformationByHandleEx (
         return TRUE;
     }
 
+    if (FileInformationClass == FileCompressionInfo) {
+        PFILE_COMPRESSION_INFO CompressionInfo;
+        FILE_COMPRESSION_INFORMATION NativeCompressionInfo;
+        IO_STATUS_BLOCK IoStatus;
+        NTSTATUS Status;
+
+        if (dwBufferSize < sizeof(FILE_COMPRESSION_INFO)) {
+            SetLastError( ERROR_INSUFFICIENT_BUFFER );
+            return FALSE;
+        }
+
+        Status = ZwQueryInformationFile( hFile,
+                                         &IoStatus,
+                                         &NativeCompressionInfo,
+                                         sizeof(NativeCompressionInfo),
+                                         FileCompressionInformation );
+        if (! NT_SUCCESS(Status)) {
+            LdkSetLastNTError( Status );
+            return FALSE;
+        }
+
+        CompressionInfo = (PFILE_COMPRESSION_INFO)lpFileInformation;
+        CompressionInfo->CompressedFileSize = NativeCompressionInfo.CompressedFileSize;
+        CompressionInfo->CompressionFormat = NativeCompressionInfo.CompressionFormat;
+        CompressionInfo->CompressionUnitShift = NativeCompressionInfo.CompressionUnitShift;
+        CompressionInfo->ChunkShift = NativeCompressionInfo.ChunkShift;
+        CompressionInfo->ClusterShift = NativeCompressionInfo.ClusterShift;
+        RtlCopyMemory( CompressionInfo->Reserved,
+                       NativeCompressionInfo.Reserved,
+                       sizeof(CompressionInfo->Reserved) );
+        return TRUE;
+    }
+
+    if (FileInformationClass == FileAlignmentInfo) {
+        PFILE_ALIGNMENT_INFO AlignmentInfo;
+        FILE_ALIGNMENT_INFORMATION NativeAlignmentInfo;
+        IO_STATUS_BLOCK IoStatus;
+        NTSTATUS Status;
+
+        if (dwBufferSize < sizeof(FILE_ALIGNMENT_INFO)) {
+            SetLastError( ERROR_INSUFFICIENT_BUFFER );
+            return FALSE;
+        }
+
+        Status = ZwQueryInformationFile( hFile,
+                                         &IoStatus,
+                                         &NativeAlignmentInfo,
+                                         sizeof(NativeAlignmentInfo),
+                                         FileAlignmentInformation );
+        if (! NT_SUCCESS(Status)) {
+            LdkSetLastNTError( Status );
+            return FALSE;
+        }
+
+        AlignmentInfo = (PFILE_ALIGNMENT_INFO)lpFileInformation;
+        AlignmentInfo->AlignmentRequirement = NativeAlignmentInfo.AlignmentRequirement;
+        return TRUE;
+    }
+
     if (! GetFileInformationByHandle( hFile,
                                       &HandleInfo )) {
         return FALSE;

--- a/test/kernel32/file.c
+++ b/test/kernel32/file.c
@@ -207,6 +207,57 @@ FileTest (
         rv = FALSE;
         goto DeleteTest;
     }
+    printf("Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n");
+    FILE_COMPRESSION_INFO CompressionInfo;
+    RtlZeroMemory( &CompressionInfo,
+                   sizeof(CompressionInfo) );
+    if (! GetFileInformationByHandleEx( hFile,
+                                        FileCompressionInfo,
+                                        &CompressionInfo,
+                                        sizeof(CompressionInfo) )) {
+        fprintf(stderr,
+                "[Failed] GetFileInformationByHandleEx(FileCompressionInfo) ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test CreateHardLinkW(Test.tmp, TestHardLink.tmp)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    if (CompressionInfo.CompressedFileSize.QuadPart < 0) {
+        fprintf(stderr,
+                "[Failed] FileCompressionInfo returned negative compressed size\n");
+        CloseHandle( hFile );
+        printf("[Failed] Test CreateHardLinkW(Test.tmp, TestHardLink.tmp)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    FILE_ALIGNMENT_INFO AlignmentInfo;
+    RtlZeroMemory( &AlignmentInfo,
+                   sizeof(AlignmentInfo) );
+    if (! GetFileInformationByHandleEx( hFile,
+                                        FileAlignmentInfo,
+                                        &AlignmentInfo,
+                                        sizeof(AlignmentInfo) )) {
+        fprintf(stderr,
+                "[Failed] GetFileInformationByHandleEx(FileAlignmentInfo) ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test CreateHardLinkW(Test.tmp, TestHardLink.tmp)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    if ((AlignmentInfo.AlignmentRequirement &
+         (AlignmentInfo.AlignmentRequirement + 1)) != 0) {
+        fprintf(stderr,
+                "[Failed] FileAlignmentInfo returned unexpected alignment mask = %lu\n",
+                AlignmentInfo.AlignmentRequirement);
+        CloseHandle( hFile );
+        printf("[Failed] Test CreateHardLinkW(Test.tmp, TestHardLink.tmp)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    printf("[Success] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n\n");
     CloseHandle( hFile );
     if (!rv || HandleInfo.nNumberOfLinks < 2) {
         fprintf(stderr,


### PR DESCRIPTION
﻿## Summary

Adds fixed-size `GetFileInformationByHandleEx` query coverage for:

- `FileCompressionInfo`
- `FileAlignmentInfo`

The Win32-facing SDK structs and fallback class constants are added to the LDK headers, and the Kernel32 implementation now forwards both classes to `ZwQueryInformationFile` using the matching native file information classes.

## Tests

- `./build.bat . x64 Debug`
- `./build.bat . x86 Debug`
- `./build.bat . ARM Debug`
- `./build.bat . ARM64 Debug`
- `cmake --build artifacts/build/ldktest-x64 --config Debug --target LdkTest`
- `cmake --build artifacts/build/win32-api-x64-fileapi --config Debug --target LdkWin32ApiTest`
- `artifacts/build/win32-api-x64-fileapi/bin/Debug/LdkWin32ApiTest.exe FileTest`
- VM driver load/unload smoke test with `LdkTest.sys`
- VM repeated load/unload smoke test with `LdkTest.sys`

VM logs were saved locally under `artifacts/vm-fileinfo-*.log`.
