### PR TITLE
Add FileStorageInfo query support

### DIFF
--- a/docs/api/file-and-handles.md
+++ b/docs/api/file-and-handles.md
@@ -30,8 +30,14 @@ attribute helpers are backed by native file information queries and setters.
 - `FileStreamInfo`
 - `FileCompressionInfo`
 - `FileAttributeTagInfo`
+- `FileStorageInfo`
 - `FileAlignmentInfo`
 - `FileIdInfo`
+
+`FileStorageInfo` is backed by the native
+`FileFsSectorSizeInformation` volume query and reports the logical sector,
+physical sector, effective physical sector, alignment offsets, and storage
+alignment flags exposed by the underlying file system stack.
 
 `SetFileInformationByHandle` currently supports:
 

--- a/include/Ldk/winbase.h
+++ b/include/Ldk/winbase.h
@@ -255,6 +255,25 @@ typedef struct _FILE_ALIGNMENT_INFO {
     ULONG AlignmentRequirement;
 } FILE_ALIGNMENT_INFO, *PFILE_ALIGNMENT_INFO;
 
+#ifndef STORAGE_INFO_FLAGS_ALIGNED_DEVICE
+#define STORAGE_INFO_FLAGS_ALIGNED_DEVICE                 0x00000001
+#define STORAGE_INFO_FLAGS_PARTITION_ALIGNED_ON_DEVICE    0x00000002
+#endif
+
+#ifndef STORAGE_INFO_OFFSET_UNKNOWN
+#define STORAGE_INFO_OFFSET_UNKNOWN 0xffffffff
+#endif
+
+typedef struct _FILE_STORAGE_INFO {
+    ULONG LogicalBytesPerSector;
+    ULONG PhysicalBytesPerSectorForAtomicity;
+    ULONG PhysicalBytesPerSectorForPerformance;
+    ULONG FileSystemEffectivePhysicalBytesPerSectorForAtomicity;
+    ULONG Flags;
+    ULONG ByteOffsetForSectorAlignment;
+    ULONG ByteOffsetForPartitionAlignment;
+} FILE_STORAGE_INFO, *PFILE_STORAGE_INFO;
+
 #ifndef FileBasicInfo
 #define FileBasicInfo ((FILE_INFO_BY_HANDLE_CLASS)0)
 #endif
@@ -284,6 +303,9 @@ typedef struct _FILE_ALIGNMENT_INFO {
 #endif
 #ifndef FileAttributeTagInfo
 #define FileAttributeTagInfo ((FILE_INFO_BY_HANDLE_CLASS)9)
+#endif
+#ifndef FileStorageInfo
+#define FileStorageInfo ((FILE_INFO_BY_HANDLE_CLASS)16)
 #endif
 #ifndef FileAlignmentInfo
 #define FileAlignmentInfo ((FILE_INFO_BY_HANDLE_CLASS)17)

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -2683,6 +2683,44 @@ GetFileInformationByHandleEx (
         return TRUE;
     }
 
+    if (FileInformationClass == FileStorageInfo) {
+        PFILE_STORAGE_INFO StorageInfo;
+        FILE_FS_SECTOR_SIZE_INFORMATION NativeStorageInfo;
+        IO_STATUS_BLOCK IoStatus;
+        NTSTATUS Status;
+
+        if (dwBufferSize < sizeof(FILE_STORAGE_INFO)) {
+            SetLastError( ERROR_INSUFFICIENT_BUFFER );
+            return FALSE;
+        }
+
+        Status = ZwQueryVolumeInformationFile( hFile,
+                                               &IoStatus,
+                                               &NativeStorageInfo,
+                                               sizeof(NativeStorageInfo),
+                                               FileFsSectorSizeInformation );
+        if (! NT_SUCCESS(Status)) {
+            LdkSetLastNTError( Status );
+            return FALSE;
+        }
+
+        StorageInfo = (PFILE_STORAGE_INFO)lpFileInformation;
+        StorageInfo->LogicalBytesPerSector =
+            NativeStorageInfo.LogicalBytesPerSector;
+        StorageInfo->PhysicalBytesPerSectorForAtomicity =
+            NativeStorageInfo.PhysicalBytesPerSectorForAtomicity;
+        StorageInfo->PhysicalBytesPerSectorForPerformance =
+            NativeStorageInfo.PhysicalBytesPerSectorForPerformance;
+        StorageInfo->FileSystemEffectivePhysicalBytesPerSectorForAtomicity =
+            NativeStorageInfo.FileSystemEffectivePhysicalBytesPerSectorForAtomicity;
+        StorageInfo->Flags = NativeStorageInfo.Flags;
+        StorageInfo->ByteOffsetForSectorAlignment =
+            NativeStorageInfo.ByteOffsetForSectorAlignment;
+        StorageInfo->ByteOffsetForPartitionAlignment =
+            NativeStorageInfo.ByteOffsetForPartitionAlignment;
+        return TRUE;
+    }
+
     if (! GetFileInformationByHandle( hFile,
                                       &HandleInfo )) {
         return FALSE;

--- a/test/kernel32/file.c
+++ b/test/kernel32/file.c
@@ -361,7 +361,7 @@ FileTest (
     }
     printf("[Success] Test GetFileInformationByHandleEx(FileStreamInfo)\n\n");
 
-    printf("Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n");
+    printf("Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n");
     FILE_COMPRESSION_INFO CompressionInfo;
     RtlZeroMemory( &CompressionInfo,
                    sizeof(CompressionInfo) );
@@ -373,7 +373,7 @@ FileTest (
                 "[Failed] GetFileInformationByHandleEx(FileCompressionInfo) ErrorCode = %d\n",
                 GetLastError());
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -381,7 +381,7 @@ FileTest (
         fprintf(stderr,
                 "[Failed] FileCompressionInfo returned negative compressed size\n");
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -397,7 +397,7 @@ FileTest (
                 "[Failed] GetFileInformationByHandleEx(FileAlignmentInfo) ErrorCode = %d\n",
                 GetLastError());
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -407,11 +407,42 @@ FileTest (
                 "[Failed] FileAlignmentInfo returned unexpected alignment mask = %lu\n",
                 AlignmentInfo.AlignmentRequirement);
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
-    printf("[Success] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo)\n\n");
+
+    FILE_STORAGE_INFO StorageInfo;
+    RtlZeroMemory( &StorageInfo,
+                   sizeof(StorageInfo) );
+    if (! GetFileInformationByHandleEx( hFile,
+                                        FileStorageInfo,
+                                        &StorageInfo,
+                                        sizeof(StorageInfo) )) {
+        fprintf(stderr,
+                "[Failed] GetFileInformationByHandleEx(FileStorageInfo) ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    if (StorageInfo.LogicalBytesPerSector == 0 ||
+        StorageInfo.PhysicalBytesPerSectorForAtomicity == 0 ||
+        StorageInfo.PhysicalBytesPerSectorForPerformance == 0 ||
+        StorageInfo.FileSystemEffectivePhysicalBytesPerSectorForAtomicity == 0) {
+        fprintf(stderr,
+                "[Failed] FileStorageInfo returned invalid sector sizes Logical = %lu Atomic = %lu Performance = %lu Effective = %lu\n",
+                StorageInfo.LogicalBytesPerSector,
+                StorageInfo.PhysicalBytesPerSectorForAtomicity,
+                StorageInfo.PhysicalBytesPerSectorForPerformance,
+                StorageInfo.FileSystemEffectivePhysicalBytesPerSectorForAtomicity);
+        CloseHandle( hFile );
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    printf("[Success] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
     CloseHandle( hFile );
     if (!rv || HandleInfo.nNumberOfLinks < 2) {
         fprintf(stderr,


### PR DESCRIPTION
## Summary

Adds `GetFileInformationByHandleEx(FileStorageInfo)` support using the native `FileFsSectorSizeInformation` volume query. The SDK-compatible `FILE_STORAGE_INFO` layout and `FileStorageInfo` selector are exposed in the LDK winbase header.

## Details

- Maps native sector size and storage alignment fields into `FILE_STORAGE_INFO`.
- Extends `FileTest` to validate nonzero logical, physical, and effective sector sizes.
- Updates the file and handle API documentation to list and describe `FileStorageInfo` support.

## Validation

- `./build.bat . x64 Debug`
- `cmake --build artifacts/build/win32-api-x64-fileapi --config Debug --target LdkWin32ApiTest`
- `artifacts/build/win32-api-x64-fileapi/bin/Debug/LdkWin32ApiTest.exe FileTest`
- `cmake --build artifacts/build/ldktest-x64 --config Debug --target LdkTest`
- `cmake --build artifacts/build/ldk_x86_Debug --config Debug --target Ldk`
- `cmake --build artifacts/build/ldk_ARM_Debug --config Debug --target Ldk`
- `cmake --build artifacts/build/ldk_ARM64_Debug --config Debug --target Ldk`
- VM driver load test: `[LdkTest] PASS all tests` with `FileStorageInfo` covered in `FileTest`.