### PR TITLE
Add FileNormalizedNameInfo query support

### DIFF
--- a/docs/api/file-and-handles.md
+++ b/docs/api/file-and-handles.md
@@ -27,6 +27,7 @@ attribute helpers are backed by native file information queries and setters.
 - `FileBasicInfo`
 - `FileStandardInfo`
 - `FileNameInfo`
+- `FileNormalizedNameInfo`
 - `FileStreamInfo`
 - `FileCompressionInfo`
 - `FileAttributeTagInfo`

--- a/include/Ldk/winbase.h
+++ b/include/Ldk/winbase.h
@@ -319,6 +319,9 @@ typedef struct _FILE_STORAGE_INFO {
 #ifndef FileRenameInfoEx
 #define FileRenameInfoEx ((FILE_INFO_BY_HANDLE_CLASS)22)
 #endif
+#ifndef FileNormalizedNameInfo
+#define FileNormalizedNameInfo ((FILE_INFO_BY_HANDLE_CLASS)24)
+#endif
 
 #define LDK_HAS_WINBASE_FILE_INFO_TYPES 1
 

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -2602,6 +2602,28 @@ GetFileInformationByHandleEx (
         return TRUE;
     }
 
+    if (FileInformationClass == FileNormalizedNameInfo) {
+        IO_STATUS_BLOCK IoStatus;
+        NTSTATUS Status;
+
+        if (dwBufferSize < (DWORD)FIELD_OFFSET(FILE_NAME_INFO, FileName)) {
+            SetLastError( ERROR_INSUFFICIENT_BUFFER );
+            return FALSE;
+        }
+
+        Status = ZwQueryInformationFile( hFile,
+                                         &IoStatus,
+                                         lpFileInformation,
+                                         dwBufferSize,
+                                         FileNormalizedNameInformation );
+        if (! NT_SUCCESS(Status)) {
+            LdkSetLastNTError( Status );
+            return FALSE;
+        }
+
+        return TRUE;
+    }
+
     if (FileInformationClass == FileStreamInfo) {
         IO_STATUS_BLOCK IoStatus;
         NTSTATUS Status;

--- a/test/kernel32/file.c
+++ b/test/kernel32/file.c
@@ -224,8 +224,11 @@ FileTest (
     BY_HANDLE_FILE_INFORMATION HandleInfo;
     rv = GetFileInformationByHandle( hFile,
                                      &HandleInfo );
+    printf("Test GetFileInformationByHandleEx(FileNameInfo / FileNormalizedNameInfo)\n");
     UCHAR FileNameInfoBuffer[FIELD_OFFSET(FILE_NAME_INFO, FileName) + (MAX_PATH * sizeof(WCHAR))];
     PFILE_NAME_INFO NameInfo = (PFILE_NAME_INFO)FileNameInfoBuffer;
+    UCHAR FileNormalizedNameInfoBuffer[FIELD_OFFSET(FILE_NAME_INFO, FileName) + (MAX_PATH * sizeof(WCHAR))];
+    PFILE_NAME_INFO NormalizedNameInfo = (PFILE_NAME_INFO)FileNormalizedNameInfoBuffer;
     RtlZeroMemory( FileNameInfoBuffer,
                    sizeof(FileNameInfoBuffer) );
     if (! GetFileInformationByHandleEx( hFile,
@@ -236,7 +239,21 @@ FileTest (
                 "[Failed] GetFileInformationByHandleEx(FileNameInfo) ErrorCode = %d\n",
                 GetLastError());
         CloseHandle( hFile );
-        printf("[Failed] Test CreateHardLinkW(Test.tmp, TestHardLink.tmp)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileNameInfo / FileNormalizedNameInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    RtlZeroMemory( FileNormalizedNameInfoBuffer,
+                   sizeof(FileNormalizedNameInfoBuffer) );
+    if (! GetFileInformationByHandleEx( hFile,
+                                        FileNormalizedNameInfo,
+                                        NormalizedNameInfo,
+                                        sizeof(FileNormalizedNameInfoBuffer) )) {
+        fprintf(stderr,
+                "[Failed] GetFileInformationByHandleEx(FileNormalizedNameInfo) ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test GetFileInformationByHandleEx(FileNameInfo / FileNormalizedNameInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -462,10 +479,23 @@ FileTest (
                           ExpectedFileNameChars * sizeof(WCHAR) ) !=
                           ExpectedFileNameChars * sizeof(WCHAR)) {
         fprintf(stderr, "[Failed] GetFileInformationByHandleEx(FileNameInfo) returned unexpected name\n");
-        printf("[Failed] Test CreateHardLinkW(Test.tmp, TestHardLink.tmp)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileNameInfo / FileNormalizedNameInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
+    ULONG NormalizedFileNameChars = NormalizedNameInfo->FileNameLength / sizeof(WCHAR);
+    if (NormalizedFileNameChars < ExpectedFileNameChars ||
+        RtlCompareMemory( NormalizedNameInfo->FileName + NormalizedFileNameChars - ExpectedFileNameChars,
+                          ExpectedFileName,
+                          ExpectedFileNameChars * sizeof(WCHAR) ) !=
+                          ExpectedFileNameChars * sizeof(WCHAR)) {
+        fprintf(stderr,
+                "[Failed] GetFileInformationByHandleEx(FileNormalizedNameInfo) returned unexpected name\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileNameInfo / FileNormalizedNameInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    printf("[Success] Test GetFileInformationByHandleEx(FileNameInfo / FileNormalizedNameInfo)\n\n");
 
     if (!DeleteFileW( L"Test.tmp" )) {
         fprintf(stderr, "[Failed] DeleteFileW(Test.tmp) ErrorCode = %d\n", GetLastError());


### PR DESCRIPTION
## Summary

Adds `GetFileInformationByHandleEx(FileNormalizedNameInfo)` support using the native `FileNormalizedNameInformation` query. The result uses the same `FILE_NAME_INFO` layout as the Win32 API.

## Details

- Defines `FileNormalizedNameInfo` when the platform headers do not provide it.
- Routes the Win32 query class to `ZwQueryInformationFile(..., FileNormalizedNameInformation)`.
- Extends `FileTest` to validate both `FileNameInfo` and `FileNormalizedNameInfo` against the expected test file suffix.
- Updates the file and handle API documentation.

## Validation

- `./build.bat . x64 Debug`
- `cmake --build artifacts/build/win32-api-x64-fileapi --config Debug --target LdkWin32ApiTest`
- `artifacts/build/win32-api-x64-fileapi/bin/Debug/LdkWin32ApiTest.exe FileTest`
- `cmake --build artifacts/build/ldktest-x64 --config Debug --target LdkTest`
- `cmake --build artifacts/build/ldk_x86_Debug --config Debug --target Ldk`
- `cmake --build artifacts/build/ldk_ARM_Debug --config Debug --target Ldk`
- `cmake --build artifacts/build/ldk_ARM64_Debug --config Debug --target Ldk`
- VM driver load test: `[LdkTest] PASS all tests` with `FileNormalizedNameInfo` covered in `FileTest`.