### PR TITLE
Tighten loader pin and unload semantics

### DIFF
--- a/docs/runtime/loader.md
+++ b/docs/runtime/loader.md
@@ -86,17 +86,20 @@ the built-in Kernel32 and NTDLL registrations expose name tables only.
 `FreeLibrary` calls `LdrUnloadDll`, which calls `LdkUnloadDll`. Dynamic modules
 are reference-counted. A balanced unload decrements the count; when it reaches
 zero, the module is removed from the module list, called with
-`DLL_PROCESS_DETACH`, and freed.
+`DLL_PROCESS_DETACH`, and freed. Invalid module handles fail instead of being
+treated as successful no-op unloads.
 
 After the dependent module has run detach and its image has been freed, its
 recorded dependency references are released. This keeps imported modules alive
 during the dependent module's detach callback, then lets automatically loaded
 dependencies unload when no other direct or dependency reference remains.
 
-`GetModuleHandleEx` supports the tested name/address lookup paths. Passing
-`GET_MODULE_HANDLE_EX_FLAG_PIN` marks a dynamic module as pinned so later
-`FreeLibrary` calls do not unload it. Pseudo modules registered by LDK itself,
-such as the built-in Kernel32 and NTDLL registrations, are not unloadable.
+`GetModuleHandleEx` supports the tested name/address lookup paths. By default it
+adds a loader reference, while `GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT`
+leaves the load count unchanged. Passing `GET_MODULE_HANDLE_EX_FLAG_PIN` marks a
+dynamic module as pinned so later `FreeLibrary` calls do not unload it. Pseudo
+modules registered by LDK itself, such as the built-in Kernel32 and NTDLL
+registrations, are not unloadable.
 
 `LdkTerminate` unregisters remaining modules before tearing down Kernel32,
 NTDLL, TEB, PEB, and heap state. This matters because loaded DLLs can run detach

--- a/src/kernel32/libloaderapi.c
+++ b/src/kernel32/libloaderapi.c
@@ -916,6 +916,11 @@ FreeLibrary (
 
 	PAGED_CODE()
 
+	if (! ARGUMENT_PRESENT(hLibModule)) {
+		SetLastError( ERROR_INVALID_HANDLE );
+		return FALSE;
+	}
+
 	ModuleHandle = LdkpMapModuleHandle( hLibModule,
 										 TRUE );
 	if (! ModuleHandle) {
@@ -926,6 +931,10 @@ FreeLibrary (
 	Status = LdrUnloadDll( ModuleHandle );
 	if (NT_SUCCESS(Status)) {
 		return TRUE;
+	}
+	if (Status == STATUS_NOT_FOUND) {
+		SetLastError( ERROR_INVALID_HANDLE );
+		return FALSE;
 	}
 	LdkSetLastNTError( Status );
 	return FALSE;

--- a/src/ldk.c
+++ b/src/ldk.c
@@ -1501,7 +1501,7 @@ LdkUnloadDll (
 		LdkpUnregisterModule( Module );
 	}
 
-	return STATUS_SUCCESS;
+	return Status;
 }
 
 NTSTATUS

--- a/test/kernel32/library.c
+++ b/test/kernel32/library.c
@@ -121,6 +121,60 @@ LibraryTest (
     }
     printf("[Success] GetProcAddress(TestFunction)\n");
 
+    HMODULE hUnchanged = NULL;
+    if (!GetModuleHandleExW( GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                             L"Test.dll",
+                             &hUnchanged ) ||
+        hUnchanged != hModule) {
+       fprintf(stderr,
+               "[Failed] GetModuleHandleExW(Test.dll, UNCHANGED_REFCOUNT) ErrorCode = %lu\n",
+               GetLastError());
+       FreeLibrary( hModule );
+       return FALSE;
+    }
+
+    HMODULE hFromAddress = NULL;
+    if (!GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                             GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                             (LPCSTR)testFn,
+                             &hFromAddress ) ||
+        hFromAddress != hModule) {
+       fprintf(stderr,
+               "[Failed] GetModuleHandleExA(TestFunction, FROM_ADDRESS) ErrorCode = %lu\n",
+               GetLastError());
+       FreeLibrary( hModule );
+       return FALSE;
+    }
+
+    HMODULE hReferenced = NULL;
+    if (!GetModuleHandleExW( 0,
+                             L"Test.dll",
+                             &hReferenced ) ||
+        hReferenced != hModule) {
+       fprintf(stderr,
+               "[Failed] GetModuleHandleExW(Test.dll) refcount ErrorCode = %lu\n",
+               GetLastError());
+       FreeLibrary( hModule );
+       return FALSE;
+    }
+
+    if (!FreeLibrary( hModule )) {
+       fprintf(stderr,
+               "[Failed] FreeLibrary(Test.dll original reference) ErrorCode = %lu\n",
+               GetLastError());
+       FreeLibrary( hReferenced );
+       return FALSE;
+    }
+    hModule = hReferenced;
+
+    if (GetModuleHandleW( L"Test.dll" ) != hModule) {
+       fprintf(stderr,
+               "[Failed] GetModuleHandleExW(Test.dll) did not keep Test.dll loaded ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    printf("[Success] GetModuleHandleEx refcount\n");
+
     HMODULE hModule2 = LoadLibraryW( L"Test.dll" );
     if (hModule2 != hModule) {
        fprintf(stderr,
@@ -395,6 +449,58 @@ LibraryTest (
        return FALSE;
     }
     printf("[Success] LoadLibraryExW LOAD_LIBRARY_AS_DATAFILE\n");
+
+    if (FreeLibrary( NULL )) {
+       fprintf(stderr,
+               "[Failed] FreeLibrary(NULL) unexpectedly succeeded\n");
+       return FALSE;
+    }
+    if (FreeLibrary( (HMODULE)INVALID_HANDLE_VALUE )) {
+       fprintf(stderr,
+               "[Failed] FreeLibrary(invalid module) unexpectedly succeeded\n");
+       return FALSE;
+    }
+    printf("[Success] FreeLibrary invalid handles\n");
+
+    HMODULE hPinnedLoad = LoadLibraryW( L"Test.dll" );
+    if (!hPinnedLoad) {
+       fprintf(stderr,
+               "[Failed] LoadLibraryW(Test.dll pin target) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+
+    HMODULE hPinned = NULL;
+    if (!GetModuleHandleExW( GET_MODULE_HANDLE_EX_FLAG_PIN,
+                             L"Test.dll",
+                             &hPinned ) ||
+        hPinned != hPinnedLoad) {
+       fprintf(stderr,
+               "[Failed] GetModuleHandleExW(Test.dll, PIN) ErrorCode = %lu\n",
+               GetLastError());
+       FreeLibrary( hPinnedLoad );
+       return FALSE;
+    }
+
+    if (!FreeLibrary( hPinnedLoad )) {
+       fprintf(stderr,
+               "[Failed] FreeLibrary(Test.dll pinned load reference) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    if (!FreeLibrary( hPinned )) {
+       fprintf(stderr,
+               "[Failed] FreeLibrary(Test.dll pinned handle) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    if (GetModuleHandleW( L"Test.dll" ) != hPinned) {
+       fprintf(stderr,
+               "[Failed] pinned Test.dll was unloaded ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    printf("[Success] GetModuleHandleEx PIN\n");
 
     printf("[Success] Library Test\n\n");
     return TRUE;


### PR DESCRIPTION
## Summary

- Make `FreeLibrary(NULL)` fail instead of mapping it to the current image.
- Return the real `LdkUnloadDll` lookup status when a module handle is not registered.
- Map unknown module unloads to `ERROR_INVALID_HANDLE` at the Kernel32 layer.
- Expand `LibraryTest` coverage for `GetModuleHandleEx` refcount, address lookup, pinning, and invalid `FreeLibrary` handles.
- Update loader documentation for the tested refcount, pin, and invalid unload behavior.

## Validation

- `LdkWin32ApiTest.exe LibraryTest` on x64
- `LdkWin32ApiTest.exe LibraryTest` on x86
- `LdkWin32ApiTest.exe LdrTest` on x64 and x86
- `cmake --build artifacts\build\ldk_x64_Debug --config Debug --target Ldk`
- `cmake --build artifacts\build\ldk_x86_Debug --config Debug --target Ldk`
- `cmake --build artifacts\build\ldk_ARM_Debug --config Debug --target Ldk`
- `cmake --build artifacts\build\ldk_ARM64_Debug --config Debug --target Ldk`
- `cmake --build artifacts\build\ldktest-x64 --config Debug --target LdkTest`
- VM load/unload: `LdkTestDbg012742` start returned `0`, service reached `RUNNING`, then stop/delete returned `0`.