### PR TITLE
Use bounded CreatePipe name formatting

### DIFF
--- a/src/kernel32/namepipe.c
+++ b/src/kernel32/namepipe.c
@@ -1,7 +1,7 @@
 ﻿#include "winbase.h"
 #include "../ldk.h"
 #include "../ntdll/ntdll.h"
-#include <stdio.h>
+#include <ntstrsafe.h>
 
 
 LONG PipeSerialNumber = 0;
@@ -38,10 +38,15 @@ CreatePipe (
     if (nSize == 0) {
         nSize = 4096;
     }
-    sprintf( PipeNameBuffer,
-             WIN32_SS_PIPE_FORMAT_STRING,
-             HandleToUlong(NtCurrentTeb()->ClientId.UniqueProcess),
-             InterlockedIncrement(&PipeSerialNumber) );
+    Status = RtlStringCbPrintfA( PipeNameBuffer,
+                                 sizeof(PipeNameBuffer),
+                                 WIN32_SS_PIPE_FORMAT_STRING,
+                                 HandleToUlong(NtCurrentTeb()->ClientId.UniqueProcess),
+                                 InterlockedIncrement(&PipeSerialNumber) );
+    if (! NT_SUCCESS(Status)) {
+        LdkSetLastNTError(Status);
+        return FALSE;
+    }
 
     RtlInitAnsiString( &PipeName,
                        PipeNameBuffer );

--- a/test/driver.c
+++ b/test/driver.c
@@ -11,6 +11,11 @@ FileTest (
     );
 
 BOOLEAN
+PipeTest (
+    VOID
+    );
+
+BOOLEAN
 HeapApiTest (
     VOID
     );
@@ -134,6 +139,7 @@ DriverEntry (
         { "LdrTest", LdrTest },
         { "FibersTest", FibersTest },
         { "FileTest", FileTest },
+        { "PipeTest", PipeTest },
         { "HeapApiTest", HeapApiTest },
         { "FormatMessageTest", FormatMessageTest },
         { "NlsTest", NlsTest },

--- a/test/kernel32/pipe.c
+++ b/test/kernel32/pipe.c
@@ -1,0 +1,147 @@
+#if _KERNEL_MODE
+#include <Ldk/Windows.h>
+
+BOOLEAN
+PipeTest (
+    VOID
+    );
+
+#ifdef ALLOC_PRAGMA
+#pragma alloc_text(PAGE, PipeTest)
+#endif
+
+#define stdout DPFLTR_INFO_LEVEL
+#define stderr DPFLTR_ERROR_LEVEL
+#define fprintf(_f_, ...)   (DbgPrintEx(DPFLTR_IHVDRIVER_ID, _f_, __VA_ARGS__))
+#define printf(...)         (fprintf(stdout, __VA_ARGS__))
+#else
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+#define PAGED_CODE()
+#endif
+
+BOOLEAN
+PipeTest (
+    VOID
+    )
+{
+    BOOLEAN Result = TRUE;
+    HANDLE ReadPipe = NULL;
+    HANDLE WritePipe = NULL;
+    DWORD BytesWritten = 0;
+    DWORD BytesRead = 0;
+    DWORD BytesAvailable = 0;
+    CHAR Buffer[8];
+    static const CHAR Message[] = "pipe";
+
+    PAGED_CODE();
+
+    printf("Pipe Test\n");
+
+    printf("Test CreatePipe / PeekNamedPipe / ReadFile / WriteFile\n");
+    if (! CreatePipe( &ReadPipe,
+                      &WritePipe,
+                      NULL,
+                      512 )) {
+        fprintf(stderr,
+                "[Failed] CreatePipe ErrorCode = %lu\n",
+                GetLastError() );
+        return FALSE;
+    }
+
+    if (! WriteFile( WritePipe,
+                     Message,
+                     sizeof(Message) - 1,
+                     &BytesWritten,
+                     NULL ) ||
+        BytesWritten != sizeof(Message) - 1) {
+        fprintf(stderr,
+                "[Failed] WriteFile(pipe) ErrorCode = %lu BytesWritten = %lu\n",
+                GetLastError(),
+                BytesWritten );
+        Result = FALSE;
+        goto Exit;
+    }
+
+    if (! PeekNamedPipe( ReadPipe,
+                         NULL,
+                         0,
+                         NULL,
+                         &BytesAvailable,
+                         NULL ) ||
+        BytesAvailable < sizeof(Message) - 1) {
+        fprintf(stderr,
+                "[Failed] PeekNamedPipe ErrorCode = %lu BytesAvailable = %lu\n",
+                GetLastError(),
+                BytesAvailable );
+        Result = FALSE;
+        goto Exit;
+    }
+
+    RtlZeroMemory( Buffer,
+                   sizeof(Buffer) );
+    if (! ReadFile( ReadPipe,
+                    Buffer,
+                    sizeof(Message) - 1,
+                    &BytesRead,
+                    NULL ) ||
+        BytesRead != sizeof(Message) - 1 ||
+        memcmp( Buffer,
+                Message,
+                sizeof(Message) - 1 ) != 0) {
+        fprintf(stderr,
+                "[Failed] ReadFile(pipe) ErrorCode = %lu BytesRead = %lu Buffer = %.*s\n",
+                GetLastError(),
+                BytesRead,
+                (int)BytesRead,
+                Buffer );
+        Result = FALSE;
+        goto Exit;
+    }
+    printf("[Success] Test CreatePipe / PeekNamedPipe / ReadFile / WriteFile\n\n");
+
+Exit:
+    if (ReadPipe != NULL) {
+        CloseHandle( ReadPipe );
+        ReadPipe = NULL;
+    }
+    if (WritePipe != NULL) {
+        CloseHandle( WritePipe );
+        WritePipe = NULL;
+    }
+
+    printf("Test repeated CreatePipe name generation\n");
+    for (ULONG Index = 0; Index < 64; Index++) {
+        if (! CreatePipe( &ReadPipe,
+                          &WritePipe,
+                          NULL,
+                          0 )) {
+            fprintf(stderr,
+                    "[Failed] Repeated CreatePipe Index = %lu ErrorCode = %lu\n",
+                    Index,
+                    GetLastError() );
+            Result = FALSE;
+            break;
+        }
+        CloseHandle( ReadPipe );
+        CloseHandle( WritePipe );
+        ReadPipe = NULL;
+        WritePipe = NULL;
+    }
+
+    if (ReadPipe != NULL) {
+        CloseHandle( ReadPipe );
+    }
+    if (WritePipe != NULL) {
+        CloseHandle( WritePipe );
+    }
+
+    if (Result) {
+        printf("[Success] Test repeated CreatePipe name generation\n\n");
+    } else {
+        printf("[Failed] Pipe Test\n\n");
+    }
+
+    return Result;
+}

--- a/test/win32/CMakeLists.txt
+++ b/test/win32/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LDK_WIN32_TEST_SOURCES
     ../kernel32/heap.c
     ../kernel32/library.c
     ../kernel32/nls.c
+    ../kernel32/pipe.c
     ../kernel32/process.c
     ../kernel32/synchapi.c
     ../kernel32/threadpool.c

--- a/test/win32/main.c
+++ b/test/win32/main.c
@@ -42,6 +42,11 @@ FileTest (
     );
 
 BOOLEAN
+PipeTest (
+    VOID
+    );
+
+BOOLEAN
 HeapApiTest (
     VOID
     );
@@ -193,6 +198,7 @@ main (
         { "LdrTest", LdrTest },
         { "FibersTest", FibersTest },
         { "FileTest", FileTest },
+        { "PipeTest", PipeTest },
         { "HeapApiTest", HeapApiTest },
         { "FormatMessageTest", FormatMessageTest },
         { "NlsTest", NlsTest },


### PR DESCRIPTION
## Summary
- Replace the internal `CreatePipe` `sprintf` call with `RtlStringCbPrintfA` and explicit NTSTATUS error handling.
- Add a repository-native `PipeTest` covering anonymous pipe create/write/peek/read and repeated pipe creation.
- Run the same pipe coverage in the Win32 baseline test project.

## Notes
This is the LDK-owned cleanup follow-up for the area discussed in #16. The external PR's reported user-controlled overflow path did not match the current `CreatePipe` code, but bounded formatting is still a cleaner implementation.

## Validation
- `cmake --build test\build_x64 --config Debug --target LdkTest`
- `cmake --build test\build_x86 --config Debug --target LdkTest`
- `cmake --build test\build_ARM --config Debug --target LdkTest`
- `cmake --build test\build_ARM64 --config Debug --target LdkTest`
- `cmake --build artifacts\build\win32-api-x64 --config Debug --target LdkWin32ApiTest`
- `cmake --build artifacts\build\win32-api-x86 --config Debug --target LdkWin32ApiTest`
- `artifacts\build\win32-api-x64\bin\Debug\LdkWin32ApiTest.exe PipeTest`
- `artifacts\build\win32-api-x86\bin\Debug\LdkWin32ApiTest.exe PipeTest`