### PR TITLE
Add DLL directory search APIs

### DIFF
--- a/docs/overview/api-support.md
+++ b/docs/overview/api-support.md
@@ -16,9 +16,9 @@ Status guide:
 
 | Area | Representative APIs | Status | Notes |
 | --- | --- | --- | --- |
-| Loader | `LoadLibraryA/W`, `LoadLibraryExA/W`, `FreeLibrary`, `GetProcAddress`, `GetModuleHandleA/W`, `GetModuleFileNameA/W` | Experimental | Supports tested name/ordinal export lookup, import-by-ordinal, load counts, pinning, basic acyclic import dependency ownership, selected `LoadLibraryExW` search flags, `DONT_RESOLVE_DLL_REFERENCES`, and resource/datafile handles. Complex dependency graphs still need workload validation. See [Loader](../runtime/loader.md). |
+| Loader | `LoadLibraryA/W`, `LoadLibraryExA/W`, `FreeLibrary`, `GetProcAddress`, `GetModuleHandleA/W`, `GetModuleFileNameA/W`, `AddDllDirectory`, `RemoveDllDirectory`, `SetDefaultDllDirectories` | Experimental | Supports tested name/ordinal export lookup, import-by-ordinal, load counts, pinning, basic acyclic import dependency ownership, process-wide user DLL directories, selected `LoadLibraryExW` search flags, `DONT_RESOLVE_DLL_REFERENCES`, and resource/datafile handles. Complex dependency graphs still need workload validation. See [Loader](../runtime/loader.md). |
 | Runtime state | `GetLastError`, `SetLastError`, `GetStartupInfoA/W`, `GetCurrentProcess`, `GetCurrentProcessId`, `OpenProcess`, `GetCurrentThread` | Partial | Process state is backed by the LDK runtime instance, while thread identity follows real kernel threads with LDK TEB sidecars. |
-| Environment and paths | `GetEnvironmentVariableA/W`, `SetEnvironmentVariableA/W`, `GetEnvironmentStringsA/W`, `GetCurrentDirectoryA/W`, `SetCurrentDirectoryA/W`, `SetDllDirectoryA/W`, `GetCommandLineA/W` | Partial | Backed by `RTL_USER_PROCESS_PARAMETERS` and LDK PEB path state. See [Environment and paths](../runtime/environment-and-paths.md). |
+| Environment and paths | `GetEnvironmentVariableA/W`, `SetEnvironmentVariableA/W`, `GetEnvironmentStringsA/W`, `GetCurrentDirectoryA/W`, `SetCurrentDirectoryA/W`, `SetDllDirectoryA/W`, `GetDllDirectoryA/W`, `GetCommandLineA/W` | Partial | Backed by `RTL_USER_PROCESS_PARAMETERS` and LDK PEB path state. See [Environment and paths](../runtime/environment-and-paths.md). |
 | Synchronization | Critical sections, condition variables, waits, `Sleep`, `WaitOnAddress`, `WakeByAddressSingle`, `WakeByAddressAll` | Partial | Common paths are tested, including multi-threaded wait-on-address stress. See [Synchronization](../runtime/synchronization.md). |
 | Threads | `CreateThread`, `OpenThread`, `ExitThread`, `GetExitCodeThread`, `GetThreadTimes`, priority helpers | Partial | Uses kernel system threads. `CREATE_SUSPENDED` is not supported. See [Threading and callbacks](../runtime/threading-and-callbacks.md). |
 | FLS | `FlsAlloc`, `FlsFree`, `FlsGetValue`, `FlsSetValue` | Partial | Stored in LDK TEB records. Callback lifetime is tied to thread exit and LDK teardown. |
@@ -36,7 +36,7 @@ Status guide:
 
 | Area | Representative APIs | Status | Notes |
 | --- | --- | --- | --- |
-| Loader | `LdrLoadDll`, `LdrUnloadDll`, `LdrGetProcedureAddress`, `LdrGetDllHandle` | Experimental | Wraps the LDK loader and module list. |
+| Loader | `LdrLoadDll`, `LdrUnloadDll`, `LdrGetProcedureAddress`, `LdrGetDllHandle` | Experimental | Wraps the LDK loader and module list. `LdrGetDllHandle` covers tested name and path-aware lookup paths. |
 | Synchronization | `RtlInitializeCriticalSection`, `RtlEnterCriticalSection`, `RtlLeaveCriticalSection`, condition-variable RTL APIs, SRW helpers | Partial | Implemented in LDK over kernel wait primitives and wait-on-address helpers. |
 | Wait-on-address | `RtlWaitOnAddress`, `RtlWakeAddressSingle`, `RtlWakeAddressAll` | Partial | Uses LDK alert-by-thread-id primitives internally. |
 | Native alert wait | `NtAlertThreadByThreadId`, `NtWaitForAlertByThreadId`, `Zw*` aliases | Partial | Pending alerts are keyed by the target `PETHREAD` object to avoid stale thread-id reuse. |

--- a/docs/runtime/environment-and-paths.md
+++ b/docs/runtime/environment-and-paths.md
@@ -46,8 +46,15 @@ callers that accidentally include a leading quote. The current directory is
 stored in the LDK process parameters and guarded with the PEB lock where needed.
 
 `SetDllDirectoryA/W` stores one process-wide user DLL directory in the LDK PEB.
-Passing `NULL` clears that directory and restores the default LDK loader search
-state.
+`GetDllDirectoryA/W` reports that stored value. Passing `NULL` to
+`SetDllDirectoryA/W` clears the directory and restores the default LDK loader
+search state.
+
+`AddDllDirectory` adds an absolute directory to the process-wide user DLL
+directory list and returns an opaque `DLL_DIRECTORY_COOKIE`. `RemoveDllDirectory`
+removes that cookie from the list. `SetDefaultDllDirectories` stores the
+process-wide default search flags used by later `LoadLibraryA/W` calls that do
+not pass explicit `LOAD_LIBRARY_SEARCH_*` flags.
 
 ## DLL search path
 
@@ -59,9 +66,9 @@ ahead of same-named DLLs in system directories.
 Selected `LoadLibraryExW` search flags override or extend that default. The
 supported subset covers the system directory, the current image directory, the
 directory of a fully qualified DLL name, the default-directory combination, and
-`LOAD_WITH_ALTERED_SEARCH_PATH`. `LOAD_LIBRARY_SEARCH_USER_DIRS` uses the
-directory set by `SetDllDirectoryA/W`; LDK does not currently maintain the full
-Windows `AddDllDirectory` list.
+`LOAD_WITH_ALTERED_SEARCH_PATH`. `LOAD_LIBRARY_SEARCH_USER_DIRS` uses both the
+single directory set by `SetDllDirectoryA/W` and the cookie list populated by
+`AddDllDirectory`.
 
 `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` requires a fully qualified DLL path, matching
 the Win32 contract. Search flags are intentionally treated as an explicit mode:

--- a/docs/runtime/loader.md
+++ b/docs/runtime/loader.md
@@ -27,12 +27,18 @@ same-named DLLs found in system directories.
 
 The tested `LoadLibraryExW` search subset includes
 `LOAD_LIBRARY_SEARCH_SYSTEM32`, `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`,
-`LOAD_LIBRARY_SEARCH_APPLICATION_DIR`, `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`, and
-`LOAD_WITH_ALTERED_SEARCH_PATH`. When a DLL is loaded from a specific directory,
-imports discovered while loading that DLL inherit the same search context where
-applicable, which lets private dependency DLLs live beside their owner DLL.
-`LOAD_LIBRARY_SEARCH_USER_DIRS` uses the single process-wide directory set by
-`SetDllDirectoryA/W`. Invalid combinations such as
+`LOAD_LIBRARY_SEARCH_APPLICATION_DIR`, `LOAD_LIBRARY_SEARCH_USER_DIRS`,
+`LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`, and `LOAD_WITH_ALTERED_SEARCH_PATH`. When a
+DLL is loaded from a specific directory, imports discovered while loading that
+DLL inherit the same search context where applicable, which lets private
+dependency DLLs live beside their owner DLL.
+
+User DLL directories are process-wide LDK PEB state. `SetDllDirectoryA/W`
+stores the single Win32-compatible directory reported by `GetDllDirectoryA/W`.
+`AddDllDirectory` appends absolute directories to a cookie list, and
+`RemoveDllDirectory` removes those cookies. `SetDefaultDllDirectories` controls
+the search flags used by later `LoadLibraryA/W` calls that do not pass explicit
+search flags. Invalid combinations such as
 `LOAD_WITH_ALTERED_SEARCH_PATH` mixed with `LOAD_LIBRARY_SEARCH_*` flags are
 rejected before the load reaches the native loader.
 
@@ -100,6 +106,11 @@ recorded dependency references are released. This keeps imported modules alive
 during the dependent module's detach callback, then lets automatically loaded
 dependencies unload when no other direct or dependency reference remains.
 
+`LdrGetDllHandle` supports name lookup and path-aware lookup when a caller
+passes a `DllPath` search string. Dynamic modules are registered with their NT
+full path so the path-aware query does not accidentally match a same-named DLL
+loaded from a different directory.
+
 `GetModuleHandleEx` supports the tested name/address lookup paths. By default it
 adds a loader reference, while `GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT`
 leaves the load count unchanged. Passing `GET_MODULE_HANDLE_EX_FLAG_PIN` marks a
@@ -120,15 +131,16 @@ failures and debugger breaks in loader paths as compatibility bugs to audit, not
 as recoverable normal behavior.
 
 The current dependency model covers tested acyclic import ownership and unload
-ordering. It is still not a full Windows loader implementation: circular import
-graphs, advanced side-by-side activation behavior, delay-load ownership, and
-arbitrary loader callback interactions are outside the current contract.
-Drivers that rely on complex DLL dependency trees should add workload-specific
-load/unload tests before using that pattern.
+ordering, including repeated owner/dependency load and unload cycles. It is
+still not a full Windows loader implementation: circular import graphs,
+advanced side-by-side activation behavior, dedicated delay-load helper
+integration, and arbitrary loader callback interactions are outside the current
+contract. Drivers that rely on complex DLL dependency trees should add
+workload-specific load/unload tests before using that pattern.
 
 The `LoadLibraryExW` flag model is also intentionally narrower than Windows:
-LDK supports `SetDllDirectoryA/W` as one process-wide user DLL directory, but it
-does not implement `AddDllDirectory`, per-thread default DLL directories,
-activation contexts, signed-target enforcement, or the full safe search mode
-policy. Unsupported flag combinations fail early instead of being silently
-treated as normal loads.
+LDK supports process-wide `SetDllDirectoryA/W`, `GetDllDirectoryA/W`,
+`AddDllDirectory`, `RemoveDllDirectory`, and `SetDefaultDllDirectories`, but it
+does not implement per-thread DLL directory state, activation contexts,
+signed-target enforcement, or the full safe search mode policy. Unsupported flag
+combinations fail early instead of being silently treated as normal loads.

--- a/include/Ldk/libloaderapi.h
+++ b/include/Ldk/libloaderapi.h
@@ -162,6 +162,29 @@ LoadLibraryExW(
 
 #endif
 
+typedef PVOID DLL_DIRECTORY_COOKIE;
+
+WINBASEAPI
+DLL_DIRECTORY_COOKIE
+WINAPI
+AddDllDirectory(
+    _In_ PCWSTR NewDirectory
+    );
+
+WINBASEAPI
+BOOL
+WINAPI
+RemoveDllDirectory(
+    _In_ DLL_DIRECTORY_COOKIE Cookie
+    );
+
+WINBASEAPI
+BOOL
+WINAPI
+SetDefaultDllDirectories(
+    _In_ DWORD DirectoryFlags
+    );
+
 WINBASEAPI
 BOOL
 WINAPI

--- a/include/Ldk/processenv.h
+++ b/include/Ldk/processenv.h
@@ -103,6 +103,22 @@ SetDllDirectoryW(
     _In_opt_ LPCWSTR lpPathName
     );
 
+WINBASEAPI
+DWORD
+WINAPI
+GetDllDirectoryA(
+    _In_ DWORD nBufferLength,
+    _Out_writes_to_opt_(nBufferLength,return + 1) LPSTR lpBuffer
+    );
+
+WINBASEAPI
+DWORD
+WINAPI
+GetDllDirectoryW(
+    _In_ DWORD nBufferLength,
+    _Out_writes_to_opt_(nBufferLength,return + 1) LPWSTR lpBuffer
+    );
+
 
 WINBASEAPI
 _NullNull_terminated_

--- a/src/kernel32/kernel32.c
+++ b/src/kernel32/kernel32.c
@@ -220,6 +220,26 @@ LDK_FUNCTION_REGISTRATION LdkpKernel32FunctionRegistration[] = {
 		SetDllDirectoryW
 	},
 	{
+		"GetDllDirectoryA",
+		GetDllDirectoryA
+	},
+	{
+		"GetDllDirectoryW",
+		GetDllDirectoryW
+	},
+	{
+		"AddDllDirectory",
+		AddDllDirectory
+	},
+	{
+		"RemoveDllDirectory",
+		RemoveDllDirectory
+	},
+	{
+		"SetDefaultDllDirectories",
+		SetDefaultDllDirectories
+	},
+	{
 		"GetStdHandle",
 		GetStdHandle
 	},

--- a/src/kernel32/libloaderapi.c
+++ b/src/kernel32/libloaderapi.c
@@ -31,15 +31,34 @@ LdkpComputeDllPath (
 	);
 
 NTSTATUS
-LdkpDuplicateDllDirectory (
-	_Out_ PUNICODE_STRING DllDirectory
+LdkpDuplicateUserDllDirectories (
+	_Out_ PUNICODE_STRING DllDirectories
+	);
+
+DWORD
+LdkpGetDefaultDllDirectories (
+	VOID
+	);
+
+VOID
+LdkpFreeHeapUnicodeString (
+	_Inout_ PUNICODE_STRING String
+	);
+
+NTSTATUS
+LdkpAppendDllPathElement (
+	_Inout_ PUNICODE_STRING SearchPath,
+	_In_ PCUNICODE_STRING Element
 	);
 
 
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(PAGE, LdkpComputeDllPath)
-#pragma alloc_text(PAGE, LdkpDuplicateDllDirectory)
+#pragma alloc_text(PAGE, LdkpAppendDllPathElement)
+#pragma alloc_text(PAGE, LdkpDuplicateUserDllDirectories)
+#pragma alloc_text(PAGE, LdkpFreeHeapUnicodeString)
+#pragma alloc_text(PAGE, LdkpGetDefaultDllDirectories)
 #pragma alloc_text(PAGE, GetModuleFileNameA)
 #pragma alloc_text(PAGE, GetModuleFileNameW)
 #pragma alloc_text(PAGE, GetModuleHandleA)
@@ -632,25 +651,103 @@ LdkpDuplicateEnvironmentPath (
 }
 
 NTSTATUS
-LdkpDuplicateDllDirectory (
-	_Out_ PUNICODE_STRING DllDirectory
+LdkpDuplicateUserDllDirectories (
+	_Out_ PUNICODE_STRING DllDirectories
 	)
 {
+	NTSTATUS Status;
+	PLIST_ENTRY Entry;
+	PLDK_DLL_DIRECTORY Directory;
+	SIZE_T RequiredLength = sizeof(UNICODE_NULL);
+	ULONG Count = 0;
+
 	PAGED_CODE();
 
-	DllDirectory->Length = 0;
-	DllDirectory->MaximumLength = 0;
-	DllDirectory->Buffer = NULL;
+	DllDirectories->Length = 0;
+	DllDirectories->MaximumLength = 0;
+	DllDirectories->Buffer = NULL;
 
 	RtlAcquirePebLock();
 	if (NtCurrentPeb()->DllDirectory.Length) {
-		NTSTATUS Status = LdkDuplicateUnicodeString( &NtCurrentPeb()->DllDirectory,
-													 DllDirectory );
+		RequiredLength += NtCurrentPeb()->DllDirectory.Length;
+		Count++;
+	}
+
+	for (Entry = NtCurrentPeb()->DllDirectoryListHead.Flink;
+		 Entry != &NtCurrentPeb()->DllDirectoryListHead;
+		 Entry = Entry->Flink) {
+		Directory = CONTAINING_RECORD( Entry,
+									   LDK_DLL_DIRECTORY,
+									   Links );
+		if (Directory->Path.Length) {
+			RequiredLength += Directory->Path.Length;
+			Count++;
+		}
+	}
+
+	if (Count > 1) {
+		RequiredLength += (Count - 1) * sizeof(WCHAR);
+	}
+
+	if (Count == 0) {
 		RtlReleasePebLock();
+		return STATUS_SUCCESS;
+	}
+
+	if (RequiredLength > MAXUSHORT) {
+		RtlReleasePebLock();
+		return STATUS_NAME_TOO_LONG;
+	}
+
+	DllDirectories->MaximumLength = (USHORT)RequiredLength;
+	DllDirectories->Buffer = RtlAllocateHeap( RtlProcessHeap(),
+											  HEAP_ZERO_MEMORY,
+											  DllDirectories->MaximumLength );
+	if (! DllDirectories->Buffer) {
+		RtlReleasePebLock();
+		return STATUS_INSUFFICIENT_RESOURCES;
+	}
+
+	Status = LdkpAppendDllPathElement( DllDirectories,
+									   &NtCurrentPeb()->DllDirectory );
+	if (! NT_SUCCESS(Status)) {
+		RtlReleasePebLock();
+		LdkpFreeHeapUnicodeString( DllDirectories );
 		return Status;
 	}
+
+	for (Entry = NtCurrentPeb()->DllDirectoryListHead.Flink;
+		 Entry != &NtCurrentPeb()->DllDirectoryListHead;
+		 Entry = Entry->Flink) {
+		Directory = CONTAINING_RECORD( Entry,
+									   LDK_DLL_DIRECTORY,
+									   Links );
+		Status = LdkpAppendDllPathElement( DllDirectories,
+										   &Directory->Path );
+		if (! NT_SUCCESS(Status)) {
+			RtlReleasePebLock();
+			LdkpFreeHeapUnicodeString( DllDirectories );
+			return Status;
+		}
+	}
+
 	RtlReleasePebLock();
 	return STATUS_SUCCESS;
+}
+
+DWORD
+LdkpGetDefaultDllDirectories (
+	VOID
+	)
+{
+	DWORD DirectoryFlags;
+
+	PAGED_CODE();
+
+	RtlAcquirePebLock();
+	DirectoryFlags = NtCurrentPeb()->DefaultDllDirectories;
+	RtlReleasePebLock();
+	return DirectoryFlags;
 }
 
 VOID
@@ -736,7 +833,7 @@ LdkpComputeDllPath (
 		goto Cleanup;
 	}
 
-	Status = LdkpDuplicateDllDirectory( &UserDllDirectories );
+	Status = LdkpDuplicateUserDllDirectories( &UserDllDirectories );
 	if (! NT_SUCCESS(Status)) {
 		goto Cleanup;
 	}
@@ -758,6 +855,10 @@ LdkpComputeDllPath (
 	}
 
 	SearchFlags = dwFlags & LDK_LOAD_LIBRARY_SEARCH_FLAGS;
+	if (! SearchFlags &&
+		! (dwFlags & LOAD_WITH_ALTERED_SEARCH_PATH)) {
+		SearchFlags = LdkpGetDefaultDllDirectories();
+	}
 	if (dwFlags & LOAD_WITH_ALTERED_SEARCH_PATH) {
 		Status = LdkpAppendDllPathElement( &SearchPath,
 										   &LoadDirectory );
@@ -850,7 +951,7 @@ Cleanup:
 	LdkpFreeHeapUnicodeString( &LoadDirectory );
 	LdkpFreeHeapUnicodeString( &ImageDirectory );
 	LdkpFreeHeapUnicodeString( &EnvironmentPath );
-	LdkFreeUnicodeString( &UserDllDirectories );
+	LdkpFreeHeapUnicodeString( &UserDllDirectories );
 	return Status;
 }
 

--- a/src/kernel32/processenv.c
+++ b/src/kernel32/processenv.c
@@ -8,13 +8,25 @@ LdkpCheckForSameCurdir (
     _In_ PUNICODE_STRING PathName
     );
 
+NTSTATUS
+LdkpDuplicateDllDirectoryString (
+    _In_opt_ PCUNICODE_STRING PathName,
+    _Out_ PUNICODE_STRING Directory
+    );
+
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(PAGE, GetCurrentDirectoryA)
 #pragma alloc_text(PAGE, GetCurrentDirectoryW)
+#pragma alloc_text(PAGE, GetDllDirectoryA)
+#pragma alloc_text(PAGE, GetDllDirectoryW)
 #pragma alloc_text(PAGE, LdkpCheckForSameCurdir)
+#pragma alloc_text(PAGE, LdkpDuplicateDllDirectoryString)
 #pragma alloc_text(PAGE, SetCurrentDirectoryA)
 #pragma alloc_text(PAGE, SetCurrentDirectoryW)
+#pragma alloc_text(PAGE, AddDllDirectory)
+#pragma alloc_text(PAGE, RemoveDllDirectory)
+#pragma alloc_text(PAGE, SetDefaultDllDirectories)
 #pragma alloc_text(PAGE, SetDllDirectoryA)
 #pragma alloc_text(PAGE, SetDllDirectoryW)
 #pragma alloc_text(PAGE, GetEnvironmentStrings)
@@ -290,6 +302,74 @@ LdkpIsDirectorySeparator (
     return Character == L'\\' || Character == L'/';
 }
 
+BOOLEAN
+LdkpIsFullyQualifiedDllDirectory (
+    _In_ PCWSTR Path
+    )
+{
+    if (! Path || ! *Path) {
+        return FALSE;
+    }
+
+    if ((Path[0] == L'\\') &&
+        Path[1] &&
+        Path[2] &&
+        Path[3] &&
+        (Path[1] == L'?') &&
+        (Path[2] == L'?') &&
+        (Path[3] == L'\\')) {
+        Path += 4;
+    }
+
+    if (LdkpIsDirectorySeparator(Path[0]) &&
+        Path[1] &&
+        LdkpIsDirectorySeparator(Path[1])) {
+        return TRUE;
+    }
+
+    return Path[0] &&
+           Path[1] &&
+           Path[2] &&
+           Path[1] == L':' &&
+           LdkpIsDirectorySeparator(Path[2]);
+}
+
+NTSTATUS
+LdkpDuplicateDllDirectoryString (
+    _In_opt_ PCUNICODE_STRING PathName,
+    _Out_ PUNICODE_STRING Directory
+    )
+{
+    NTSTATUS Status;
+
+    Directory->Buffer = NULL;
+    Directory->Length = 0;
+    Directory->MaximumLength = 0;
+
+    if (! ARGUMENT_PRESENT(PathName) ||
+        ! PathName->Buffer ||
+        ! PathName->Length) {
+        return STATUS_SUCCESS;
+    }
+
+    if (PathName->Length > MAXUSHORT - sizeof(UNICODE_NULL)) {
+        return STATUS_NAME_TOO_LONG;
+    }
+
+    Directory->MaximumLength = PathName->Length + sizeof(UNICODE_NULL);
+    Status = LdkAllocateUnicodeString( Directory );
+    if (! NT_SUCCESS(Status)) {
+        return Status;
+    }
+
+    RtlCopyMemory( Directory->Buffer,
+                   PathName->Buffer,
+                   PathName->Length );
+    Directory->Length = PathName->Length;
+    Directory->Buffer[Directory->Length / sizeof(WCHAR)] = UNICODE_NULL;
+    return STATUS_SUCCESS;
+}
+
 BOOL
 LdkpSetDllDirectory (
     _In_opt_ PCUNICODE_STRING PathName
@@ -297,42 +377,15 @@ LdkpSetDllDirectory (
 {
     UNICODE_STRING NewDirectory;
     UNICODE_STRING OldDirectory;
-    SIZE_T PathLength;
-    BOOLEAN AppendSeparator;
+    NTSTATUS Status;
 
     PAGED_CODE();
 
-    NewDirectory.Buffer = NULL;
-    NewDirectory.Length = 0;
-    NewDirectory.MaximumLength = 0;
-
-    if (ARGUMENT_PRESENT(PathName) &&
-        PathName->Buffer &&
-        PathName->Length) {
-        AppendSeparator = ! LdkpIsDirectorySeparator(
-                              PathName->Buffer[(PathName->Length / sizeof(WCHAR)) - 1] );
-        PathLength = PathName->Length +
-                     (AppendSeparator ? sizeof(WCHAR) : 0);
-
-        if (PathLength > MAXUSHORT - sizeof(UNICODE_NULL)) {
-            LdkSetLastNTError( STATUS_NAME_TOO_LONG );
-            return FALSE;
-        }
-
-        NewDirectory.MaximumLength = (USHORT)(PathLength + sizeof(UNICODE_NULL));
-        if (! NT_SUCCESS(LdkAllocateUnicodeString( &NewDirectory ))) {
-            LdkSetLastNTError( STATUS_NO_MEMORY );
-            return FALSE;
-        }
-
-        RtlCopyMemory( NewDirectory.Buffer,
-                       PathName->Buffer,
-                       PathName->Length );
-        NewDirectory.Length = PathName->Length;
-        if (AppendSeparator) {
-            NewDirectory.Buffer[NewDirectory.Length / sizeof(WCHAR)] = L'\\';
-            NewDirectory.Length += sizeof(WCHAR);
-        }
+    Status = LdkpDuplicateDllDirectoryString( PathName,
+                                              &NewDirectory );
+    if (! NT_SUCCESS(Status)) {
+        LdkSetLastNTError( Status );
+        return FALSE;
     }
 
     RtlAcquirePebLock();
@@ -341,6 +394,283 @@ LdkpSetDllDirectory (
     RtlReleasePebLock();
 
     LdkFreeUnicodeString( &OldDirectory );
+    return TRUE;
+}
+
+WINBASEAPI
+DWORD
+WINAPI
+GetDllDirectoryW (
+    _In_ DWORD nBufferLength,
+    _Out_writes_to_opt_(nBufferLength,return + 1) LPWSTR lpBuffer
+    )
+{
+    UNICODE_STRING Directory;
+    DWORD Length;
+    DWORD Required;
+    NTSTATUS Status = STATUS_SUCCESS;
+
+    PAGED_CODE();
+
+    Directory.Buffer = NULL;
+    Directory.Length = 0;
+    Directory.MaximumLength = 0;
+
+    RtlAcquirePebLock();
+    if (NtCurrentPeb()->DllDirectory.Length) {
+        Status = LdkDuplicateUnicodeString( &NtCurrentPeb()->DllDirectory,
+                                            &Directory );
+    }
+    RtlReleasePebLock();
+
+    if (! NT_SUCCESS(Status)) {
+        LdkSetLastNTError( Status );
+        return 0;
+    }
+
+    Length = Directory.Length / sizeof(WCHAR);
+    Required = Length + 1;
+
+    if (Length == 0) {
+        if (nBufferLength == 0) {
+            return Required;
+        }
+        if (! lpBuffer) {
+            SetLastError( ERROR_INVALID_PARAMETER );
+            return 0;
+        }
+        lpBuffer[0] = UNICODE_NULL;
+        return 0;
+    }
+
+    if (nBufferLength == 0) {
+        LdkFreeUnicodeString( &Directory );
+        return Required;
+    }
+
+    if (! lpBuffer) {
+        LdkFreeUnicodeString( &Directory );
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return 0;
+    }
+
+    if (nBufferLength <= Length) {
+        lpBuffer[0] = UNICODE_NULL;
+        LdkFreeUnicodeString( &Directory );
+        return Required;
+    }
+
+    RtlCopyMemory( lpBuffer,
+                   Directory.Buffer,
+                   Directory.Length );
+    lpBuffer[Length] = UNICODE_NULL;
+    LdkFreeUnicodeString( &Directory );
+    return Length;
+}
+
+WINBASEAPI
+DWORD
+WINAPI
+GetDllDirectoryA (
+    _In_ DWORD nBufferLength,
+    _Out_writes_to_opt_(nBufferLength,return + 1) LPSTR lpBuffer
+    )
+{
+    UNICODE_STRING Directory;
+    ULONG ByteCount;
+    ULONG BytesWritten;
+    DWORD Required;
+    NTSTATUS Status = STATUS_SUCCESS;
+
+    PAGED_CODE();
+
+    Directory.Buffer = NULL;
+    Directory.Length = 0;
+    Directory.MaximumLength = 0;
+
+    RtlAcquirePebLock();
+    if (NtCurrentPeb()->DllDirectory.Length) {
+        Status = LdkDuplicateUnicodeString( &NtCurrentPeb()->DllDirectory,
+                                            &Directory );
+    }
+    RtlReleasePebLock();
+
+    if (! NT_SUCCESS(Status)) {
+        LdkSetLastNTError( Status );
+        return 0;
+    }
+
+    if (Directory.Length == 0) {
+        if (nBufferLength == 0) {
+            return 1;
+        }
+        if (! lpBuffer) {
+            SetLastError( ERROR_INVALID_PARAMETER );
+            return 0;
+        }
+        lpBuffer[0] = ANSI_NULL;
+        return 0;
+    }
+
+    Status = RtlUnicodeToMultiByteSize( &ByteCount,
+                                        Directory.Buffer,
+                                        Directory.Length );
+    if (! NT_SUCCESS(Status)) {
+        LdkFreeUnicodeString( &Directory );
+        LdkSetLastNTError( Status );
+        return 0;
+    }
+
+    Required = ByteCount + 1;
+    if (nBufferLength == 0) {
+        LdkFreeUnicodeString( &Directory );
+        return Required;
+    }
+
+    if (! lpBuffer) {
+        LdkFreeUnicodeString( &Directory );
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return 0;
+    }
+
+    if (nBufferLength <= ByteCount) {
+        lpBuffer[0] = ANSI_NULL;
+        LdkFreeUnicodeString( &Directory );
+        return Required;
+    }
+
+    Status = RtlUnicodeToMultiByteN( lpBuffer,
+                                     nBufferLength - 1,
+                                     &BytesWritten,
+                                     Directory.Buffer,
+                                     Directory.Length );
+    if (! NT_SUCCESS(Status)) {
+        LdkFreeUnicodeString( &Directory );
+        LdkSetLastNTError( Status );
+        return 0;
+    }
+
+    lpBuffer[BytesWritten] = ANSI_NULL;
+    LdkFreeUnicodeString( &Directory );
+    return BytesWritten;
+}
+
+WINBASEAPI
+DLL_DIRECTORY_COOKIE
+WINAPI
+AddDllDirectory (
+    _In_ PCWSTR NewDirectory
+    )
+{
+    UNICODE_STRING PathName;
+    PLDK_DLL_DIRECTORY Directory;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    if (! LdkpIsFullyQualifiedDllDirectory( NewDirectory )) {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return NULL;
+    }
+
+    RtlInitUnicodeString( &PathName,
+                          NewDirectory );
+
+    Directory = RtlAllocateHeap( RtlProcessHeap(),
+                                 HEAP_ZERO_MEMORY,
+                                 sizeof(*Directory) );
+    if (! Directory) {
+        LdkSetLastNTError( STATUS_NO_MEMORY );
+        return NULL;
+    }
+
+    Status = LdkpDuplicateDllDirectoryString( &PathName,
+                                              &Directory->Path );
+    if (! NT_SUCCESS(Status)) {
+        RtlFreeHeap( RtlProcessHeap(),
+                     0,
+                     Directory );
+        LdkSetLastNTError( Status );
+        return NULL;
+    }
+
+    RtlAcquirePebLock();
+    InsertTailList( &NtCurrentPeb()->DllDirectoryListHead,
+                    &Directory->Links );
+    RtlReleasePebLock();
+
+    return (DLL_DIRECTORY_COOKIE)Directory;
+}
+
+WINBASEAPI
+BOOL
+WINAPI
+RemoveDllDirectory (
+    _In_ DLL_DIRECTORY_COOKIE Cookie
+    )
+{
+    PLDK_DLL_DIRECTORY Directory;
+    PLIST_ENTRY Entry;
+    BOOLEAN Found = FALSE;
+
+    PAGED_CODE();
+
+    if (! Cookie) {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return FALSE;
+    }
+
+    Directory = (PLDK_DLL_DIRECTORY)Cookie;
+
+    RtlAcquirePebLock();
+    for (Entry = NtCurrentPeb()->DllDirectoryListHead.Flink;
+         Entry != &NtCurrentPeb()->DllDirectoryListHead;
+         Entry = Entry->Flink) {
+        if (CONTAINING_RECORD( Entry,
+                               LDK_DLL_DIRECTORY,
+                               Links ) == Directory) {
+            RemoveEntryList( &Directory->Links );
+            Found = TRUE;
+            break;
+        }
+    }
+    RtlReleasePebLock();
+
+    if (! Found) {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return FALSE;
+    }
+
+    LdkFreeUnicodeString( &Directory->Path );
+    RtlFreeHeap( RtlProcessHeap(),
+                 0,
+                 Directory );
+    return TRUE;
+}
+
+WINBASEAPI
+BOOL
+WINAPI
+SetDefaultDllDirectories (
+    _In_ DWORD DirectoryFlags
+    )
+{
+    const DWORD ValidFlags = LOAD_LIBRARY_SEARCH_APPLICATION_DIR |
+                             LOAD_LIBRARY_SEARCH_USER_DIRS |
+                             LOAD_LIBRARY_SEARCH_SYSTEM32 |
+                             LOAD_LIBRARY_SEARCH_DEFAULT_DIRS;
+
+    PAGED_CODE();
+
+    if (DirectoryFlags == 0 ||
+        FlagOn(DirectoryFlags, ~ValidFlags)) {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return FALSE;
+    }
+
+    RtlAcquirePebLock();
+    NtCurrentPeb()->DefaultDllDirectories = DirectoryFlags;
+    RtlReleasePebLock();
     return TRUE;
 }
 

--- a/src/ldk.c
+++ b/src/ldk.c
@@ -1218,6 +1218,107 @@ LdkGetModuleByName (
 	return Status;
 }
 
+NTSTATUS
+LdkpResolveDllNameToNtPath (
+	_In_opt_ PWSTR DllPath,
+	_In_ PUNICODE_STRING DllName,
+	_Out_ PUNICODE_STRING NtFileName
+	)
+{
+	UNICODE_STRING FullDllName;
+	BOOLEAN Result;
+
+	NtFileName->Length = 0;
+	NtFileName->MaximumLength = 0;
+	NtFileName->Buffer = NULL;
+
+	FullDllName.MaximumLength = 4096 * sizeof(WCHAR);
+	FullDllName.Buffer = RtlAllocateHeap( RtlProcessHeap(),
+										  0,
+										  FullDllName.MaximumLength );
+	if (! FullDllName.Buffer) {
+		return STATUS_INSUFFICIENT_RESOURCES;
+	}
+
+retry:
+	FullDllName.Length = (USHORT)RtlDosSearchPath_U( DllPath ? DllPath : NtCurrentPeb()->ProcessParameters->DllPath.Buffer,
+													 DllName->Buffer,
+													 NULL,
+													 FullDllName.MaximumLength - sizeof(UNICODE_NULL),
+													 FullDllName.Buffer,
+													 NULL );
+	if (FullDllName.Length == 0) {
+		RtlFreeHeap( RtlProcessHeap(),
+					 0,
+					 FullDllName.Buffer );
+		return STATUS_DLL_NOT_FOUND;
+	}
+	if (FullDllName.Length + sizeof(UNICODE_NULL) > FullDllName.MaximumLength) {
+		FullDllName.MaximumLength = FullDllName.Length + sizeof(UNICODE_NULL);
+		PVOID Buffer = RtlReAllocateHeap( RtlProcessHeap(),
+										  0,
+										  FullDllName.Buffer,
+										  FullDllName.MaximumLength );
+		if (! Buffer) {
+			RtlFreeHeap( RtlProcessHeap(),
+						 0,
+						 FullDllName.Buffer );
+			return STATUS_INSUFFICIENT_RESOURCES;
+		}
+		FullDllName.Buffer = Buffer;
+		goto retry;
+	}
+	FullDllName.Buffer[FullDllName.Length / sizeof(WCHAR)] = UNICODE_NULL;
+
+	Result = RtlDosPathNameToNtPathName_U( FullDllName.Buffer,
+										   NtFileName,
+										   NULL,
+										   NULL );
+	RtlFreeHeap( RtlProcessHeap(),
+				 0,
+				 FullDllName.Buffer );
+	return Result ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL;
+}
+
+NTSTATUS
+LdkpGetModuleByNtPath (
+	_In_ PCUNICODE_STRING NtFileName,
+	_Out_ PLDK_MODULE *Module
+	)
+{
+	NTSTATUS Status;
+	ANSI_STRING FullPathName;
+	PLIST_ENTRY NextEntry;
+
+	Status = LdkUnicodeStringToAnsiString( &FullPathName,
+										   NtFileName,
+										   TRUE );
+	if (! NT_SUCCESS(Status)) {
+		return Status;
+	}
+
+	Status = STATUS_NOT_FOUND;
+	LdkpAcquireModuleListShared();
+	for (NextEntry = LdkCurrentPeb()->ModuleListHead.Flink;
+		 NextEntry != &LdkCurrentPeb()->ModuleListHead;
+		 NextEntry = NextEntry->Flink) {
+		PLDK_MODULE FoundModule = CONTAINING_RECORD( NextEntry,
+													 LDK_MODULE,
+													 ActiveLinks );
+		if (FoundModule->FullPathName.Buffer &&
+			_stricmp( FoundModule->FullPathName.Buffer,
+					  FullPathName.Buffer ) == 0) {
+			*Module = FoundModule;
+			Status = STATUS_SUCCESS;
+			break;
+		}
+	}
+	LdkpReleaseModuleList();
+
+	LdkFreeAnsiString( &FullPathName );
+	return Status;
+}
+
 
 
 _Ret_maybenull_
@@ -1271,11 +1372,35 @@ LdkGetDllHandle (
     _Out_ PVOID *DllHandle
     )
 {
-	UNREFERENCED_PARAMETER(DllPath);
 	UNREFERENCED_PARAMETER(DllCharacteristics);
 
 	NTSTATUS Status;
 	ANSI_STRING Name;
+	UNICODE_STRING NtFileName;
+
+	*DllHandle = NULL;
+
+	if (DllPath) {
+		Status = LdkpResolveDllNameToNtPath( DllPath,
+											 DllName,
+											 &NtFileName );
+		if (! NT_SUCCESS(Status)) {
+			return Status;
+		}
+
+		PLDK_MODULE PathModule;
+		Status = LdkpGetModuleByNtPath( &NtFileName,
+										&PathModule );
+		RtlFreeHeap( RtlProcessHeap(),
+					 0,
+					 NtFileName.Buffer );
+		if (! NT_SUCCESS(Status)) {
+			return Status;
+		}
+
+		*DllHandle = (PathModule->Base) ? PathModule->Base : (PVOID)PathModule;
+		return STATUS_SUCCESS;
+	}
 
 	Status = LdkUnicodeStringToAnsiString( &Name,
 										   DllName,
@@ -1420,7 +1545,7 @@ retry:
 		Name.MaximumLength = Name.Length = (USHORT)(wcslen( Name.Buffer ) * sizeof(WCHAR));
 
 		Status = LdkRegisterModule( &Name,
-									DllName,
+									&NtFileName,
 									*DllHandle,
 									ImageSize,
 									&RegisteredModule );

--- a/src/peb.c
+++ b/src/peb.c
@@ -13,10 +13,16 @@ LDK_PEB LdkpPeb;
 
 UNICODE_STRING NtSystemRoot;
 
+VOID
+LdkpFreeDllDirectoryList (
+    VOID
+    );
+
 
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(INIT, LdkpInitializePeb)
+#pragma alloc_text(PAGE, LdkpFreeDllDirectoryList)
 #pragma alloc_text(PAGE, LdkpTerminatePeb)
 #endif
 
@@ -387,6 +393,35 @@ LdkpInitializeProcessParameters (
 }
 
 VOID
+LdkpFreeDllDirectoryList (
+    VOID
+    )
+{
+    PLIST_ENTRY Entry;
+    PLDK_DLL_DIRECTORY Directory;
+
+    PAGED_CODE();
+
+    if (! LdkpPeb.DllDirectoryListHead.Flink ||
+        ! LdkpPeb.DllDirectoryListHead.Blink) {
+        return;
+    }
+
+    while (! IsListEmpty( &LdkpPeb.DllDirectoryListHead )) {
+        Entry = RemoveHeadList( &LdkpPeb.DllDirectoryListHead );
+        Directory = CONTAINING_RECORD( Entry,
+                                       LDK_DLL_DIRECTORY,
+                                       Links );
+        LdkFreeUnicodeString( &Directory->Path );
+        RtlFreeHeap( RtlProcessHeap(),
+                     0,
+                     Directory );
+    }
+
+    InitializeListHead( &LdkpPeb.DllDirectoryListHead );
+}
+
+VOID
 LdkpUninitializeProcessParameters (
     VOID
     )
@@ -406,6 +441,8 @@ LdkpUninitializeProcessParameters (
 
     LdkFreeUnicodeString( &LdkpProcessParameters.DllPath );
     LdkFreeUnicodeString( &LdkpPeb.DllDirectory );
+    LdkpFreeDllDirectoryList();
+    LdkpPeb.DefaultDllDirectories = 0;
     LdkFreeUnicodeString( &LdkpProcessParameters.CurrentDirectory.DosPath );
     LdkFreeUnicodeString( &LdkpProcessParameters.ImagePathName );
     RtlFreeHeap( RtlProcessHeap(),
@@ -509,6 +546,9 @@ LdkpInitializePeb (
 		LdkFreeUnicodeString( &LdkpPeb.RegistryPath );
         return STATUS_INSUFFICIENT_RESOURCES;
     }
+    InitializeListHead( &LdkpPeb.DllDirectoryListHead );
+    LdkpPeb.DefaultDllDirectories = 0;
+
     Status = LdkpInitializeProcessParameters( DriverObject,
                                               RegistryPath );
 	if (! NT_SUCCESS(Status)) {

--- a/src/peb.h
+++ b/src/peb.h
@@ -46,6 +46,11 @@ typedef struct _RTL_USER_PROCESS_PARAMETERS {
      ULONG EnvironmentSize;
 } RTL_USER_PROCESS_PARAMETERS, *PRTL_USER_PROCESS_PARAMETERS;
 
+typedef struct _LDK_DLL_DIRECTORY {
+	LIST_ENTRY Links;
+	UNICODE_STRING Path;
+} LDK_DLL_DIRECTORY, *PLDK_DLL_DIRECTORY;
+
 typedef struct _LDK_PEB {
 
 	ULONG NtGlobalFlag;
@@ -65,6 +70,8 @@ typedef struct _LDK_PEB {
 	PDRIVER_OBJECT DriverObject;
 	UNICODE_STRING RegistryPath;
 	UNICODE_STRING DllDirectory;
+	LIST_ENTRY DllDirectoryListHead;
+	ULONG DefaultDllDirectories;
 
 	ULONG ProcessId;
 	HANDLE RealProcessId;

--- a/test/kernel32/library.c
+++ b/test/kernel32/library.c
@@ -151,6 +151,28 @@ VerifyResourceOnlyLoad (
     return TRUE;
 }
 
+static
+BOOL
+CopyWideAsciiForTest (
+    _In_ LPCWSTR Source,
+    _Out_writes_(BufferCch) LPSTR Buffer,
+    _In_ DWORD BufferCch
+    )
+{
+    DWORD Index;
+
+    for (Index = 0; Source[Index] != UNICODE_NULL; Index++) {
+        if (Index + 1 >= BufferCch ||
+            Source[Index] > 0x7f) {
+            return FALSE;
+        }
+        Buffer[Index] = (CHAR)Source[Index];
+    }
+
+    Buffer[Index] = ANSI_NULL;
+    return TRUE;
+}
+
 BOOLEAN
 LibraryTest (
     VOID
@@ -159,7 +181,10 @@ LibraryTest (
     PAGED_CODE();
 
     WCHAR DllDirectory[MAX_PATH];
+    WCHAR DllDirectoryProbe[MAX_PATH];
     WCHAR DependencyOwnerPath[MAX_PATH];
+    CHAR DllDirectoryA[MAX_PATH];
+    CHAR DllDirectoryProbeA[MAX_PATH];
     HMODULE hFailAttach;
 
     printf("Library Test\n");
@@ -178,6 +203,24 @@ LibraryTest (
                GetLastError());
        return FALSE;
     }
+    if (GetDllDirectoryW( 0,
+                          NULL ) != 1) {
+       fprintf(stderr,
+               "[Failed] GetDllDirectoryW(empty query) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    DllDirectoryProbe[0] = L'X';
+    if (GetDllDirectoryW( RTL_NUMBER_OF(DllDirectoryProbe),
+                          DllDirectoryProbe ) != 0 ||
+        DllDirectoryProbe[0] != UNICODE_NULL) {
+       fprintf(stderr,
+               "[Failed] GetDllDirectoryW(empty buffer) ErrorCode = %lu Value = %ws\n",
+               GetLastError(),
+               DllDirectoryProbe);
+       return FALSE;
+    }
+    printf("[Success] GetDllDirectoryW empty state\n");
 
     HMODULE hModule = LoadLibraryW( L"Test.dll" );
     if (!hModule) {
@@ -537,6 +580,79 @@ LibraryTest (
                GetLastError());
        return FALSE;
     }
+    DWORD DllDirectoryLength = (DWORD)wcslen( DllDirectory );
+    if (GetDllDirectoryW( 0,
+                          NULL ) != DllDirectoryLength + 1) {
+       fprintf(stderr,
+               "[Failed] GetDllDirectoryW(test directory query) ErrorCode = %lu\n",
+               GetLastError());
+       SetDllDirectoryW( NULL );
+       return FALSE;
+    }
+    DllDirectoryProbe[0] = L'X';
+    if (GetDllDirectoryW( 1,
+                          DllDirectoryProbe ) != DllDirectoryLength + 1 ||
+        DllDirectoryProbe[0] != UNICODE_NULL) {
+       fprintf(stderr,
+               "[Failed] GetDllDirectoryW(test directory small buffer) ErrorCode = %lu\n",
+               GetLastError());
+       SetDllDirectoryW( NULL );
+       return FALSE;
+    }
+    if (GetDllDirectoryW( RTL_NUMBER_OF(DllDirectoryProbe),
+                          DllDirectoryProbe ) != DllDirectoryLength ||
+        wcscmp( DllDirectoryProbe,
+                DllDirectory ) != 0) {
+       fprintf(stderr,
+               "[Failed] GetDllDirectoryW(test directory) ErrorCode = %lu Value = %ws Expected = %ws\n",
+               GetLastError(),
+               DllDirectoryProbe,
+               DllDirectory);
+       SetDllDirectoryW( NULL );
+       return FALSE;
+    }
+    if (!CopyWideAsciiForTest( DllDirectory,
+                               DllDirectoryA,
+                               RTL_NUMBER_OF(DllDirectoryA) )) {
+       fprintf(stderr,
+               "[Failed] test DLL directory is not ASCII-compatible for GetDllDirectoryA\n");
+       SetDllDirectoryW( NULL );
+       return FALSE;
+    }
+    DWORD DllDirectoryALength = 0;
+    while (DllDirectoryA[DllDirectoryALength] != ANSI_NULL) {
+       DllDirectoryALength++;
+    }
+    if (GetDllDirectoryA( 0,
+                          NULL ) != DllDirectoryALength + 1) {
+       fprintf(stderr,
+               "[Failed] GetDllDirectoryA(test directory query) ErrorCode = %lu\n",
+               GetLastError());
+       SetDllDirectoryW( NULL );
+       return FALSE;
+    }
+    DWORD DllDirectoryAReturn = GetDllDirectoryA( RTL_NUMBER_OF(DllDirectoryProbeA),
+                                                  DllDirectoryProbeA );
+    DWORD DllDirectoryAActualLength = 0;
+    while (DllDirectoryProbeA[DllDirectoryAActualLength] != ANSI_NULL) {
+       DllDirectoryAActualLength++;
+    }
+    if ((DllDirectoryAReturn != DllDirectoryAActualLength &&
+         DllDirectoryAReturn + 1 != DllDirectoryAActualLength) ||
+        strcmp( DllDirectoryProbeA,
+                DllDirectoryA ) != 0) {
+       fprintf(stderr,
+               "[Failed] GetDllDirectoryA(test directory) Return = %lu ActualLength = %lu ExpectedLength = %lu ErrorCode = %lu Value = %s Expected = %s\n",
+               DllDirectoryAReturn,
+               DllDirectoryAActualLength,
+               DllDirectoryALength,
+               GetLastError(),
+               DllDirectoryProbeA,
+               DllDirectoryA);
+       SetDllDirectoryW( NULL );
+       return FALSE;
+    }
+    printf("[Success] GetDllDirectoryA/W test directory\n");
 
     HMODULE hUserDirs = LoadLibraryExW( L"DependencyOwner.dll",
                                         NULL,
@@ -579,6 +695,71 @@ LibraryTest (
        return FALSE;
     }
     printf("[Success] LoadLibraryExW SEARCH_USER_DIRS\n");
+
+    if (AddDllDirectory( L"relative-directory" ) != NULL ||
+        GetLastError() != ERROR_INVALID_PARAMETER) {
+       fprintf(stderr,
+               "[Failed] AddDllDirectory(relative) was not rejected ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+
+    DLL_DIRECTORY_COOKIE UserCookie = AddDllDirectory( DllDirectory );
+    if (!UserCookie) {
+       fprintf(stderr,
+               "[Failed] AddDllDirectory(test directory) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+
+    HMODULE hAddedUserDir = LoadLibraryExW( L"DependencyOwner.dll",
+                                            NULL,
+                                            LOAD_LIBRARY_SEARCH_USER_DIRS );
+    if (!hAddedUserDir) {
+       fprintf(stderr,
+               "[Failed] LoadLibraryExW(DependencyOwner.dll, AddDllDirectory user dir) ErrorCode = %lu\n",
+               GetLastError());
+       RemoveDllDirectory( UserCookie );
+       return FALSE;
+    }
+    dependencyOwnerFn = (TEST_FN)GetProcAddress( hAddedUserDir, "DependencyOwnerFunction" );
+    if (!dependencyOwnerFn ||
+        dependencyOwnerFn(10) != 34) {
+       fprintf(stderr,
+               "[Failed] AddDllDirectory DependencyOwnerFunction ErrorCode = %lu\n",
+               GetLastError());
+       FreeLibrary( hAddedUserDir );
+       RemoveDllDirectory( UserCookie );
+       return FALSE;
+    }
+    if (!FreeLibrary( hAddedUserDir )) {
+       fprintf(stderr,
+               "[Failed] FreeLibrary(DependencyOwner.dll AddDllDirectory) ErrorCode = %lu\n",
+               GetLastError());
+       RemoveDllDirectory( UserCookie );
+       return FALSE;
+    }
+    if (GetModuleHandleW( L"AutoDependency.dll" ) != NULL) {
+       fprintf(stderr,
+               "[Failed] AutoDependency.dll stayed loaded after AddDllDirectory owner unload ErrorCode = %lu\n",
+               GetLastError());
+       RemoveDllDirectory( UserCookie );
+       return FALSE;
+    }
+    if (!RemoveDllDirectory( UserCookie )) {
+       fprintf(stderr,
+               "[Failed] RemoveDllDirectory(test directory) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    if (LoadLibraryExW( L"DependencyOwner.dll",
+                        NULL,
+                        LOAD_LIBRARY_SEARCH_USER_DIRS ) != NULL) {
+       fprintf(stderr,
+               "[Failed] SEARCH_USER_DIRS succeeded after RemoveDllDirectory\n");
+       return FALSE;
+    }
+    printf("[Success] AddDllDirectory / RemoveDllDirectory\n");
 
     HMODULE hDontResolve = LoadLibraryExW( L"DependencyOwner.dll",
                                            NULL,
@@ -677,6 +858,44 @@ LibraryTest (
     }
     printf("[Success] LoadLibraryExW LOAD_WITH_ALTERED_SEARCH_PATH\n");
 
+    for (DWORD Loop = 0; Loop < 16; Loop++) {
+       HMODULE hStress = LoadLibraryExW( DependencyOwnerPath,
+                                         NULL,
+                                         LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR );
+       if (!hStress) {
+          fprintf(stderr,
+                  "[Failed] Dependency graph stress LoadLibraryExW loop %lu ErrorCode = %lu\n",
+                  Loop,
+                  GetLastError());
+          return FALSE;
+       }
+       dependencyOwnerFn = (TEST_FN)GetProcAddress( hStress, "DependencyOwnerFunction" );
+       if (!dependencyOwnerFn ||
+           dependencyOwnerFn((LONG)Loop) != (LONG)Loop + 24) {
+          fprintf(stderr,
+                  "[Failed] Dependency graph stress DependencyOwnerFunction loop %lu ErrorCode = %lu\n",
+                  Loop,
+                  GetLastError());
+          FreeLibrary( hStress );
+          return FALSE;
+       }
+       if (!FreeLibrary( hStress )) {
+          fprintf(stderr,
+                  "[Failed] Dependency graph stress FreeLibrary loop %lu ErrorCode = %lu\n",
+                  Loop,
+                  GetLastError());
+          return FALSE;
+       }
+       if (GetModuleHandleW( L"AutoDependency.dll" ) != NULL) {
+          fprintf(stderr,
+                  "[Failed] AutoDependency.dll stayed loaded after dependency stress loop %lu ErrorCode = %lu\n",
+                  Loop,
+                  GetLastError());
+          return FALSE;
+       }
+    }
+    printf("[Success] Dependency graph load/unload stress\n");
+
     if (!VerifyResourceOnlyLoad( L"Test.dll",
                                  LOAD_LIBRARY_AS_DATAFILE,
                                  "LOAD_LIBRARY_AS_DATAFILE" )) {
@@ -746,6 +965,68 @@ LibraryTest (
        return FALSE;
     }
     printf("[Success] GetModuleHandleEx PIN\n");
+
+    if (SetDefaultDllDirectories( 0 ) ||
+        GetLastError() != ERROR_INVALID_PARAMETER) {
+       fprintf(stderr,
+               "[Failed] SetDefaultDllDirectories(0) was not rejected ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+
+    DLL_DIRECTORY_COOKIE DefaultCookie = AddDllDirectory( DllDirectory );
+    if (!DefaultCookie) {
+       fprintf(stderr,
+               "[Failed] AddDllDirectory(default search directory) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    if (!SetDefaultDllDirectories( LOAD_LIBRARY_SEARCH_USER_DIRS )) {
+       fprintf(stderr,
+               "[Failed] SetDefaultDllDirectories(USER_DIRS) ErrorCode = %lu\n",
+               GetLastError());
+       RemoveDllDirectory( DefaultCookie );
+       return FALSE;
+    }
+
+    HMODULE hDefaultSearch = LoadLibraryW( L"DependencyOwner.dll" );
+    if (!hDefaultSearch) {
+       fprintf(stderr,
+               "[Failed] LoadLibraryW(DependencyOwner.dll) with default user dirs ErrorCode = %lu\n",
+               GetLastError());
+       RemoveDllDirectory( DefaultCookie );
+       return FALSE;
+    }
+    dependencyOwnerFn = (TEST_FN)GetProcAddress( hDefaultSearch, "DependencyOwnerFunction" );
+    if (!dependencyOwnerFn ||
+        dependencyOwnerFn(10) != 34) {
+       fprintf(stderr,
+               "[Failed] default user dirs DependencyOwnerFunction ErrorCode = %lu\n",
+               GetLastError());
+       FreeLibrary( hDefaultSearch );
+       RemoveDllDirectory( DefaultCookie );
+       return FALSE;
+    }
+    if (!FreeLibrary( hDefaultSearch )) {
+       fprintf(stderr,
+               "[Failed] FreeLibrary(DependencyOwner.dll default user dirs) ErrorCode = %lu\n",
+               GetLastError());
+       RemoveDllDirectory( DefaultCookie );
+       return FALSE;
+    }
+    if (!RemoveDllDirectory( DefaultCookie )) {
+       fprintf(stderr,
+               "[Failed] RemoveDllDirectory(default search directory) ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    if (GetModuleHandleW( L"AutoDependency.dll" ) != NULL) {
+       fprintf(stderr,
+               "[Failed] AutoDependency.dll stayed loaded after default user dirs owner unload ErrorCode = %lu\n",
+               GetLastError());
+       return FALSE;
+    }
+    printf("[Success] SetDefaultDllDirectories USER_DIRS\n");
 
     printf("[Success] Library Test\n\n");
     return TRUE;

--- a/test/ntdll/ldr.c
+++ b/test/ntdll/ldr.c
@@ -278,6 +278,20 @@ LdrTest (
         goto Cleanup;
     }
 
+    LookupHandle = NULL;
+    Status = LdrGetDllHandle( DllPath,
+                              NULL,
+                              &DllName,
+                              &LookupHandle );
+    if (! NT_SUCCESS(Status) ||
+        LookupHandle != DllHandle) {
+        printf("[Failed] LdrGetDllHandle(Test.dll, path-aware) Status = 0x%08x Handle = %p Lookup = %p\n",
+               Status,
+               DllHandle,
+               LookupHandle);
+        goto Cleanup;
+    }
+
     Status = LdrUnloadDll( DllHandle2 );
     DllHandle2 = NULL;
     if (! NT_SUCCESS(Status)) {


### PR DESCRIPTION
## Summary

- Add `GetDllDirectoryA/W`, `AddDllDirectory`, `RemoveDllDirectory`, and `SetDefaultDllDirectories` to the LDK Win32 surface.
- Store process-wide DLL directory state in the LDK PEB and feed it into `LOAD_LIBRARY_SEARCH_USER_DIRS` and default `LoadLibraryA/W` search behavior.
- Make `LdrGetDllHandle` path-aware when `DllPath` is supplied by comparing against registered NT full paths.
- Extend loader tests for DLL directory APIs, default search flags, path-aware native lookup, and repeated dependency owner/load/unload cycles.
- Update loader, environment/path, and API support docs with the new behavior and remaining delay-load limitations.

## Validation

- Built `LdkTest` Debug for `x64`, `x86`, `ARM64`, and `ARM`.
- Ran Win32 baseline `LdkWin32ApiTest` x64 full suite successfully.
- Ran Win32 baseline x86 `LibraryTest` and `LdrTest` successfully.
- Ran VM driver load/start/query/stop/delete using latest x64 `LdkTest.sys` successfully.
  - Log: `D:\VMs\Win11KD\ldk-dll-dir-185854.log`
- Ran `git diff --check`.