### PR TITLE
Support threadpool callback environments

### DIFF
--- a/src/kernel32/threadpoolapiset.c
+++ b/src/kernel32/threadpoolapiset.c
@@ -1,5 +1,7 @@
 ﻿#include "winbase.h"
 
+#include <Ldk/ntdll/ntldr.h>
+
 #define TAG_FREE_MODULE_ENTRY		'mFdL'
 typedef struct _LDK_FREE_MODULE_ENTRY {
 	SINGLE_LIST_ENTRY Links;
@@ -32,15 +34,14 @@ typedef struct _TP_WORK
 
 #define LDK_TP_WORK_FLAGS_DELETE_REQUESTED			0x00000001
 #define LDK_TP_WORK_FLAGS_CANCEL_REQUESTED			0x00000002
-#define LDK_TP_WORK_FLAGS_STARTED_BIT_INDEX			2
-#define LDK_TP_WORK_FLAGS_STARTED					(1 << (LDK_TP_WORK_FLAGS_STARTED_BIT_INDEX))
 	LONG Flags;
+	LONG OutstandingCount;
 
 	KEVENT Event;
 
     PVOID CallbackParameter;
     PTP_WORK_CALLBACK WorkCallback;
-    PTP_CALLBACK_ENVIRON CallbackEnvironment;
+    TP_CALLBACK_ENVIRON CallbackEnvironment;
 } TP_WORK, *PTP_WORK;
 
 NPAGED_LOOKASIDE_LIST LdkpThreadpoolWorkLookaside;
@@ -82,11 +83,29 @@ LdkpThreadpoolWokerThreadRoutine (
     _In_ PLDK_THREAD_POOL_WORK_ITEM Item
     );
 
+NTSTATUS
+LdkpCaptureThreadpoolCallbackEnvironment (
+	_In_opt_ PTP_CALLBACK_ENVIRON Source,
+	_Out_ PTP_CALLBACK_ENVIRON Destination
+	);
+
+VOID
+LdkpDereferenceThreadpoolWork (
+	_Inout_ PTP_WORK Work
+	);
+
+VOID
+LdkpCompleteThreadpoolWorkItem (
+	_Inout_ PTP_WORK Work
+	);
+
 
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(INIT, LdkpInitializeThreadpoolApiset)
 #pragma alloc_text(PAGE, LdkpTerminateThreadpoolApiset)
+#pragma alloc_text(PAGE, LdkpCaptureThreadpoolCallbackEnvironment)
+#pragma alloc_text(PAGE, CreateThreadpoolWork)
 #pragma alloc_text(PAGE, WaitForThreadpoolWorkCallbacks)
 #endif
 
@@ -144,6 +163,83 @@ LdkpTerminateThreadpoolApiset (
 	ExDeleteNPagedLookasideList( &LdkpFreeModuleEntryLookaside );
 }
 
+NTSTATUS
+LdkpCaptureThreadpoolCallbackEnvironment (
+	_In_opt_ PTP_CALLBACK_ENVIRON Source,
+	_Out_ PTP_CALLBACK_ENVIRON Destination
+	)
+{
+	PAGED_CODE();
+
+	if (! ARGUMENT_PRESENT(Source)) {
+		*Destination = LdkpDefaultCallbackEnviron;
+		return STATUS_SUCCESS;
+	}
+
+	if (Source->Version != 1 &&
+		Source->Version != 3) {
+		return STATUS_INVALID_PARAMETER;
+	}
+
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
+	if (Source->Version == 3 &&
+		Source->Size != sizeof(TP_CALLBACK_ENVIRON)) {
+		return STATUS_INVALID_PARAMETER;
+	}
+
+	if (Source->Version == 3 &&
+		Source->CallbackPriority >= TP_CALLBACK_PRIORITY_INVALID) {
+		return STATUS_INVALID_PARAMETER;
+	}
+#endif
+
+	if ((Source->Pool != NULL &&
+		 Source->Pool != &LdkpDefaultThreadPool) ||
+		Source->CleanupGroup != NULL ||
+		Source->CleanupGroupCancelCallback != NULL ||
+		Source->FinalizationCallback != NULL) {
+		return STATUS_NOT_SUPPORTED;
+	}
+
+	if (Source->ActivationContext != NULL &&
+		Source->ActivationContext != (struct _ACTIVATION_CONTEXT *)(LONG_PTR)-1) {
+		return STATUS_NOT_SUPPORTED;
+	}
+
+	*Destination = *Source;
+	if (Destination->Pool == NULL) {
+		Destination->Pool = &LdkpDefaultThreadPool;
+	}
+	return STATUS_SUCCESS;
+}
+
+VOID
+LdkpDereferenceThreadpoolWork (
+	_Inout_ PTP_WORK Work
+	)
+{
+	if (InterlockedDecrement( &Work->ReferenceCount ) == 0) {
+		ExFreeToNPagedLookasideList( &LdkpThreadpoolWorkLookaside,
+									 Work );
+	}
+}
+
+VOID
+LdkpCompleteThreadpoolWorkItem (
+	_Inout_ PTP_WORK Work
+	)
+{
+	if (InterlockedDecrement( &Work->OutstandingCount ) == 0) {
+		InterlockedAnd( &Work->Flags,
+						~LDK_TP_WORK_FLAGS_CANCEL_REQUESTED );
+		KeSetEvent( &Work->Event,
+					IO_NO_INCREMENT,
+					FALSE );
+	}
+
+	LdkpDereferenceThreadpoolWork( Work );
+}
+
 
 
 WINBASEAPI
@@ -156,9 +252,12 @@ CreateThreadpoolWork (
     _In_opt_ PTP_CALLBACK_ENVIRON pcbe
     )
 {
-	if (ARGUMENT_PRESENT(pcbe)) {
-		LDK_DIAGNOSTIC_BREAK();
-		LdkSetLastNTError(STATUS_NOT_SUPPORTED);
+	NTSTATUS Status;
+
+	PAGED_CODE();
+
+	if (! ARGUMENT_PRESENT(pfnwk)) {
+		SetLastError( ERROR_INVALID_PARAMETER );
 		return NULL;
 	}
 
@@ -168,15 +267,24 @@ CreateThreadpoolWork (
 		return NULL;
 	}
 
+	Status = LdkpCaptureThreadpoolCallbackEnvironment( pcbe,
+													   &work->CallbackEnvironment );
+	if (! NT_SUCCESS(Status)) {
+		ExFreeToNPagedLookasideList( &LdkpThreadpoolWorkLookaside,
+									 work );
+		LdkSetLastNTError( Status );
+		return NULL;
+	}
+
 	KeInitializeEvent( &work->Event,
 					   NotificationEvent,
-					   FALSE );
+					   TRUE );
 
 	work->ReferenceCount = 1;
 	work->Flags = 0;
+	work->OutstandingCount = 0;
 	work->WorkCallback = pfnwk;
 	work->CallbackParameter = pv;
-	work->CallbackEnvironment = pcbe ? pcbe : &LdkpDefaultCallbackEnviron;
 	return work;
 }
 
@@ -189,49 +297,63 @@ LdkpThreadpoolWokerThreadRoutine (
     )
 {
 	PTP_WORK Work = Item->Work;
+	SINGLE_LIST_ENTRY ModuleList;
+	BOOLEAN InvokeCallback;
+	HMODULE RaceDll;
+	BOOLEAN ReleaseRaceDll;
+	NTSTATUS Status;
 
-	if (FlagOn(Work->Flags, LDK_TP_WORK_FLAGS_CANCEL_REQUESTED)) {
-		InterlockedDecrement( &Work->ReferenceCount );
-		return;
-	}
+	InvokeCallback = ! FlagOn( InterlockedCompareExchange( &Work->Flags,
+															0,
+															0 ),
+							   LDK_TP_WORK_FLAGS_CANCEL_REQUESTED );
 
 	TP_CALLBACK_INSTANCE Instance;
 	Instance.ModuleList.Next = NULL;
 	KeInitializeSpinLock( &Instance.Lock );
 	Instance.DeletePending = FALSE;
 
-	Work->WorkCallback( &Instance,
-						Work->CallbackParameter,
-						Work );
+	ReleaseRaceDll = FALSE;
+	RaceDll = (HMODULE)Work->CallbackEnvironment.RaceDll;
+	if (InvokeCallback &&
+		RaceDll != NULL) {
+		Status = LdrAddRefDll( 0,
+							   RaceDll );
+		ReleaseRaceDll = NT_SUCCESS(Status);
+	}
 
-	KeSetEvent( &Work->Event,
-				IO_NO_INCREMENT,
-				FALSE );
+	if (InvokeCallback) {
+		Work->WorkCallback( &Instance,
+							Work->CallbackParameter,
+							Work );
+	}
 
 	KIRQL OldIrql;
 	KeAcquireSpinLock( &Instance.Lock,
 					   &OldIrql );
 	Instance.DeletePending = TRUE;
-	PSINGLE_LIST_ENTRY Entry = PopEntryList( &Instance.ModuleList );
+	ModuleList.Next = Instance.ModuleList.Next;
+	Instance.ModuleList.Next = NULL;
+	KeReleaseSpinLock( &Instance.Lock,
+					   OldIrql );
+
+	PSINGLE_LIST_ENTRY Entry = ModuleList.Next;
 	while (Entry) {
+		PSINGLE_LIST_ENTRY NextEntry = Entry->Next;
 		PLDK_FREE_MODULE_ENTRY module = CONTAINING_RECORD(Entry, LDK_FREE_MODULE_ENTRY, Links);
 		FreeLibrary( module->hModule );
 		ExFreeToNPagedLookasideList( &LdkpFreeModuleEntryLookaside,
 									 Entry );
-		Entry = PopEntryList( &Instance.ModuleList );
+		Entry = NextEntry;
 	}
-	KeReleaseSpinLock( &Instance.Lock,
-					   OldIrql );
 
-	InterlockedDecrement( &Work->ReferenceCount );
-
-	if (FlagOn(Work->Flags, LDK_TP_WORK_FLAGS_DELETE_REQUESTED)) {
-		ExFreeToNPagedLookasideList( &LdkpThreadpoolWorkLookaside,
-									 Work );
+	if (ReleaseRaceDll) {
+		FreeLibrary( RaceDll );
 	}
 
 	ExFreeToNPagedLookasideList( &LdkpThreadpoolWorkQueItemLookaside,
 								 Item );
+	LdkpCompleteThreadpoolWorkItem( Work );
 }
 
 WINBASEAPI
@@ -241,24 +363,27 @@ SubmitThreadpoolWork (
     _Inout_ PTP_WORK pwk
     )
 {
-	if (InterlockedIncrement( &pwk->ReferenceCount ) <= 1) {
-		LDK_DIAGNOSTIC_BREAK();
+	if (FlagOn( InterlockedCompareExchange( &pwk->Flags,
+											0,
+											0 ),
+				LDK_TP_WORK_FLAGS_DELETE_REQUESTED )) {
 		LdkSetLastNTError( STATUS_DELETE_PENDING );
 		return;
 	}
 
-	if (InterlockedBitTestAndSet( &pwk->Flags,
-								  LDK_TP_WORK_FLAGS_STARTED_BIT_INDEX )) {
-		LDK_DIAGNOSTIC_BREAK();
-		LdkSetLastNTError(STATUS_ALREADY_REGISTERED);
-		InterlockedDecrement( &pwk->ReferenceCount );
-		return;
-	}
+	InterlockedIncrement( &pwk->ReferenceCount );
+	InterlockedIncrement( &pwk->OutstandingCount );
+	KeResetEvent( &pwk->Event );
 
 	PLDK_THREAD_POOL_WORK_ITEM item = ExAllocateFromNPagedLookasideList( &LdkpThreadpoolWorkQueItemLookaside );
 	if (!item) {
 		LdkSetLastNTError( STATUS_INSUFFICIENT_RESOURCES );
-		InterlockedDecrement( &pwk->ReferenceCount );
+		if (InterlockedDecrement( &pwk->OutstandingCount ) == 0) {
+			KeSetEvent( &pwk->Event,
+						IO_NO_INCREMENT,
+						FALSE );
+		}
+		LdkpDereferenceThreadpoolWork( pwk );
 		return;
 	}
 
@@ -285,16 +410,13 @@ WaitForThreadpoolWorkCallbacks (
 	PAGED_CODE();
 
 	if (InterlockedIncrement( &pwk->ReferenceCount ) <= 1) {
-		LDK_DIAGNOSTIC_BREAK();
 		LdkSetLastNTError( STATUS_DELETE_PENDING );
 		return;
 	}
 
-	if (fCancelPendingCallbacks && (! FlagOn(pwk->Flags, LDK_TP_WORK_FLAGS_STARTED))) {
+	if (fCancelPendingCallbacks) {
 		InterlockedOr( &pwk->Flags,
 					   LDK_TP_WORK_FLAGS_CANCEL_REQUESTED );
-		ASSERT(InterlockedDecrement( &pwk->ReferenceCount ) > 0);
-		return;
 	}
 
 	NTSTATUS Status = KeWaitForSingleObject( &pwk->Event,
@@ -305,7 +427,11 @@ WaitForThreadpoolWorkCallbacks (
 	if (! NT_SUCCESS(Status)) {
 		LdkSetLastNTError( Status );
 	}
-	ASSERT(InterlockedDecrement( &pwk->ReferenceCount ) > 0);
+	if (fCancelPendingCallbacks) {
+		InterlockedAnd( &pwk->Flags,
+						~LDK_TP_WORK_FLAGS_CANCEL_REQUESTED );
+	}
+	LdkpDereferenceThreadpoolWork( pwk );
 }
 
 WINBASEAPI
@@ -331,21 +457,27 @@ FreeLibraryWhenCallbackReturns (
     _In_ HMODULE mod
     )
 {
+	PLDK_FREE_MODULE_ENTRY Module;
 	KIRQL OldIrql;
+
+	Module = ExAllocateFromNPagedLookasideList( &LdkpFreeModuleEntryLookaside );
+	if (! Module) {
+		return;
+	}
+	Module->hModule = mod;
+
 	KeAcquireSpinLock( &pci->Lock,
 					   &OldIrql );
 
 	if (pci->DeletePending) {
 		KeReleaseSpinLock( &pci->Lock,
 						   OldIrql );
+		ExFreeToNPagedLookasideList( &LdkpFreeModuleEntryLookaside,
+									 Module );
 		return;
 	}
-	PLDK_FREE_MODULE_ENTRY Module = ExAllocateFromNPagedLookasideList( &LdkpFreeModuleEntryLookaside );
-	if (Module) {
-		Module->hModule = mod;
-		PushEntryList( &pci->ModuleList,
-					   &Module->Links );
-	}
+	PushEntryList( &pci->ModuleList,
+				   &Module->Links );
 	KeReleaseSpinLock( &pci->Lock,
 					   OldIrql );
 }

--- a/test/kernel32/threadpool.c
+++ b/test/kernel32/threadpool.c
@@ -25,11 +25,29 @@ ThreadPoolTestWorkCallback (
     _Inout_     PTP_WORK              Work
     );
 
+VOID
+NTAPI
+ThreadPoolTestRaceDllCallback (
+    _Inout_     PTP_CALLBACK_INSTANCE Instance,
+    _Inout_opt_ PVOID                 Context,
+    _Inout_     PTP_WORK              Work
+    );
+
+VOID
+NTAPI
+ThreadPoolTestDeferredFreeCallback (
+    _Inout_     PTP_CALLBACK_INSTANCE Instance,
+    _Inout_opt_ PVOID                 Context,
+    _Inout_     PTP_WORK              Work
+    );
+
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(PAGE, LegacyThreadPoolTest)
 #pragma alloc_text(PAGE, LegacyThreadWorkFunction)
 #pragma alloc_text(PAGE, ThreadPoolTest)
 #pragma alloc_text(PAGE, ThreadPoolTestWorkCallback)
+#pragma alloc_text(PAGE, ThreadPoolTestRaceDllCallback)
+#pragma alloc_text(PAGE, ThreadPoolTestDeferredFreeCallback)
 #endif
 #else
 #include <windows.h>
@@ -38,6 +56,12 @@ ThreadPoolTestWorkCallback (
 #define DbgPrint        printf
 #define PAGED_CODE()
 #endif
+
+typedef struct _THREADPOOL_MODULE_CONTEXT {
+    HMODULE Module;
+    LONG Count;
+    LONG ModuleWasLoaded;
+} THREADPOOL_MODULE_CONTEXT, *PTHREADPOOL_MODULE_CONTEXT;
 
 DWORD
 WINAPI
@@ -92,6 +116,47 @@ ThreadPoolTestWorkCallback (
     InterlockedDecrement((PLONG)Context);
 }
 
+VOID
+NTAPI
+ThreadPoolTestRaceDllCallback (
+    _Inout_     PTP_CALLBACK_INSTANCE Instance,
+    _Inout_opt_ PVOID                 Context,
+    _Inout_     PTP_WORK              Work
+    )
+{
+    PTHREADPOOL_MODULE_CONTEXT ModuleContext = (PTHREADPOOL_MODULE_CONTEXT)Context;
+
+    UNREFERENCED_PARAMETER(Instance);
+    UNREFERENCED_PARAMETER(Work);
+
+    PAGED_CODE();
+
+    FreeLibrary( ModuleContext->Module );
+    if (GetModuleHandleW( L"Test.dll" ) != NULL) {
+        InterlockedIncrement( &ModuleContext->ModuleWasLoaded );
+    }
+    InterlockedIncrement( &ModuleContext->Count );
+}
+
+VOID
+NTAPI
+ThreadPoolTestDeferredFreeCallback (
+    _Inout_     PTP_CALLBACK_INSTANCE Instance,
+    _Inout_opt_ PVOID                 Context,
+    _Inout_     PTP_WORK              Work
+    )
+{
+    PTHREADPOOL_MODULE_CONTEXT ModuleContext = (PTHREADPOOL_MODULE_CONTEXT)Context;
+
+    UNREFERENCED_PARAMETER(Work);
+
+    PAGED_CODE();
+
+    FreeLibraryWhenCallbackReturns( Instance,
+                                    ModuleContext->Module );
+    InterlockedIncrement( &ModuleContext->Count );
+}
+
 BOOLEAN
 ThreadPoolTest (
     VOID
@@ -99,13 +164,20 @@ ThreadPoolTest (
 {
     PTP_WORK works[10] = { NULL, };
     LONG count = ARRAYSIZE(works);
+    PTP_WORK work = NULL;
+    TP_CALLBACK_ENVIRON CallbackEnvironment;
+    THREADPOOL_MODULE_CONTEXT ModuleContext;
+    BOOLEAN Result = FALSE;
 
     PAGED_CODE();
+    RtlZeroMemory( &ModuleContext,
+                   sizeof(ModuleContext) );
 
     for (int i = 0; i < ARRAYSIZE(works); ++i) {
         works[i] = CreateThreadpoolWork(ThreadPoolTestWorkCallback, &count, NULL);
         if (works[i] == NULL) {
-            goto Cleanup;
+            DbgPrint("[Failed] CreateThreadpoolWork basic ErrorCode = %lu\n", GetLastError());
+            goto FinalCleanup;
         }
     }
 
@@ -113,13 +185,152 @@ ThreadPoolTest (
         SubmitThreadpoolWork(works[i]);
     }
 
-Cleanup:
     for (int i = 0; i < ARRAYSIZE(works); ++i) {
         if (works[i]) {
             WaitForThreadpoolWorkCallbacks(works[i], FALSE);
             CloseThreadpoolWork(works[i]);
+            works[i] = NULL;
         }
     }
 
-    return count == 0;
+    if (count != 0) {
+        DbgPrint("[Failed] Threadpool basic callbacks Count = %ld\n", count);
+        goto FinalCleanup;
+    }
+
+    count = 2;
+    work = CreateThreadpoolWork(ThreadPoolTestWorkCallback, &count, NULL);
+    if (work == NULL) {
+        DbgPrint("[Failed] CreateThreadpoolWork reuse ErrorCode = %lu\n", GetLastError());
+        goto FinalCleanup;
+    }
+
+    SubmitThreadpoolWork(work);
+    WaitForThreadpoolWorkCallbacks(work, FALSE);
+    SubmitThreadpoolWork(work);
+    WaitForThreadpoolWorkCallbacks(work, FALSE);
+    CloseThreadpoolWork(work);
+    work = NULL;
+
+    if (count != 0) {
+        DbgPrint("[Failed] Threadpool reuse Count = %ld\n", count);
+        goto FinalCleanup;
+    }
+
+    TpInitializeCallbackEnviron( &CallbackEnvironment );
+    TpSetCallbackLongFunction( &CallbackEnvironment );
+    TpSetCallbackPersistent( &CallbackEnvironment );
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
+    TpSetCallbackPriority( &CallbackEnvironment,
+                           TP_CALLBACK_PRIORITY_HIGH );
+#endif
+
+    count = 1;
+    work = CreateThreadpoolWork(ThreadPoolTestWorkCallback, &count, &CallbackEnvironment);
+    if (work == NULL) {
+        DbgPrint("[Failed] CreateThreadpoolWork callback environment ErrorCode = %lu\n", GetLastError());
+        goto FinalCleanup;
+    }
+    SubmitThreadpoolWork(work);
+    WaitForThreadpoolWorkCallbacks(work, FALSE);
+    CloseThreadpoolWork(work);
+    work = NULL;
+    TpDestroyCallbackEnviron( &CallbackEnvironment );
+
+    if (count != 0) {
+        DbgPrint("[Failed] Threadpool callback environment Count = %ld\n", count);
+        goto FinalCleanup;
+    }
+
+    RtlZeroMemory( &ModuleContext,
+                   sizeof(ModuleContext) );
+    ModuleContext.Module = LoadLibraryW( L"Test.dll" );
+    if (ModuleContext.Module == NULL) {
+        DbgPrint("[Failed] LoadLibraryW(Test.dll) for RaceWithDll ErrorCode = %lu\n", GetLastError());
+        goto FinalCleanup;
+    }
+
+    TpInitializeCallbackEnviron( &CallbackEnvironment );
+    TpSetCallbackRaceWithDll( &CallbackEnvironment,
+                              ModuleContext.Module );
+    work = CreateThreadpoolWork(ThreadPoolTestRaceDllCallback, &ModuleContext, &CallbackEnvironment);
+    if (work == NULL) {
+        DbgPrint("[Failed] CreateThreadpoolWork RaceWithDll ErrorCode = %lu\n", GetLastError());
+        FreeLibrary( ModuleContext.Module );
+        ModuleContext.Module = NULL;
+        goto FinalCleanup;
+    }
+    SubmitThreadpoolWork(work);
+    WaitForThreadpoolWorkCallbacks(work, FALSE);
+    CloseThreadpoolWork(work);
+    work = NULL;
+    TpDestroyCallbackEnviron( &CallbackEnvironment );
+
+    if (ModuleContext.Count != 1 ||
+        ModuleContext.ModuleWasLoaded != 1 ||
+        GetModuleHandleW( L"Test.dll" ) != NULL) {
+        DbgPrint("[Failed] Threadpool RaceWithDll Count = %ld Loaded = %ld Handle = %p\n",
+                 ModuleContext.Count,
+                 ModuleContext.ModuleWasLoaded,
+                 GetModuleHandleW( L"Test.dll" ));
+        if (GetModuleHandleW( L"Test.dll" ) != NULL) {
+            FreeLibrary( ModuleContext.Module );
+        }
+        ModuleContext.Module = NULL;
+        goto FinalCleanup;
+    }
+    ModuleContext.Module = NULL;
+
+    RtlZeroMemory( &ModuleContext,
+                   sizeof(ModuleContext) );
+    ModuleContext.Module = LoadLibraryW( L"Test.dll" );
+    if (ModuleContext.Module == NULL) {
+        DbgPrint("[Failed] LoadLibraryW(Test.dll) for deferred free ErrorCode = %lu\n", GetLastError());
+        goto FinalCleanup;
+    }
+
+    work = CreateThreadpoolWork(ThreadPoolTestDeferredFreeCallback, &ModuleContext, NULL);
+    if (work == NULL) {
+        DbgPrint("[Failed] CreateThreadpoolWork deferred free ErrorCode = %lu\n", GetLastError());
+        FreeLibrary( ModuleContext.Module );
+        ModuleContext.Module = NULL;
+        goto FinalCleanup;
+    }
+    SubmitThreadpoolWork(work);
+    WaitForThreadpoolWorkCallbacks(work, FALSE);
+    CloseThreadpoolWork(work);
+    work = NULL;
+
+    if (ModuleContext.Count != 1 ||
+        GetModuleHandleW( L"Test.dll" ) != NULL) {
+        DbgPrint("[Failed] Threadpool deferred free Count = %ld Handle = %p\n",
+                 ModuleContext.Count,
+                 GetModuleHandleW( L"Test.dll" ));
+        if (GetModuleHandleW( L"Test.dll" ) != NULL) {
+            FreeLibrary( ModuleContext.Module );
+        }
+        ModuleContext.Module = NULL;
+        goto FinalCleanup;
+    }
+    ModuleContext.Module = NULL;
+
+    DbgPrint("[Success] Threadpool callback environment and reuse\n");
+    Result = TRUE;
+
+FinalCleanup:
+    if (work) {
+        WaitForThreadpoolWorkCallbacks(work, TRUE);
+        CloseThreadpoolWork(work);
+    }
+    for (int i = 0; i < ARRAYSIZE(works); ++i) {
+        if (works[i]) {
+            WaitForThreadpoolWorkCallbacks(works[i], TRUE);
+            CloseThreadpoolWork(works[i]);
+        }
+    }
+    if (ModuleContext.Module != NULL &&
+        GetModuleHandleW( L"Test.dll" ) != NULL) {
+        FreeLibrary( ModuleContext.Module );
+    }
+    return Result;
 }


### PR DESCRIPTION
## Summary

- Add supported `TP_CALLBACK_ENVIRON` capture for threadpool work objects.
- Allow reusable `PTP_WORK` submissions and track outstanding callbacks explicitly.
- Support `TpSetCallbackRaceWithDll` and `FreeLibraryWhenCallbackReturns` lifetime handling.
- Extend threadpool tests for callback environments, work reuse, race-with-DLL, and deferred module release.

## Validation

- Built x64 Debug driver.
- Built x86, x64, ARM, and ARM64 Debug driver targets.
- Ran Win32 API baseline `ThreadPoolTest` on x86 and x64.
- Loaded and unloaded `LdkTest` in the VM with service name `LdkTest`.
- Confirmed WinDbg `.lastevent` was clean after unload and VMware Tools stayed running.