### PR TITLE
Support file I/O priority hints

### DIFF
--- a/docs/api/file-and-handles.md
+++ b/docs/api/file-and-handles.md
@@ -47,6 +47,7 @@ alignment flags exposed by the underlying file system stack.
 - `FileRenameInfoEx`
 - `FileAllocationInfo`
 - `FileEndOfFileInfo`
+- `FileIoPriorityHintInfo`
 - `FileDispositionInfo`
 - `FileDispositionInfoEx`
 

--- a/include/Ldk/winbase.h
+++ b/include/Ldk/winbase.h
@@ -221,6 +221,17 @@ typedef struct _FILE_END_OF_FILE_INFO {
     LARGE_INTEGER EndOfFile;
 } FILE_END_OF_FILE_INFO, *PFILE_END_OF_FILE_INFO;
 
+typedef enum _PRIORITY_HINT {
+    IoPriorityHintVeryLow = 0,
+    IoPriorityHintLow,
+    IoPriorityHintNormal,
+    MaximumIoPriorityHintType
+} PRIORITY_HINT;
+
+typedef struct _FILE_IO_PRIORITY_HINT_INFO {
+    PRIORITY_HINT PriorityHint;
+} FILE_IO_PRIORITY_HINT_INFO, *PFILE_IO_PRIORITY_HINT_INFO;
+
 typedef struct _FILE_STREAM_INFO {
     DWORD NextEntryOffset;
     DWORD StreamNameLength;

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -3071,6 +3071,36 @@ SetFileInformationByHandle (
         return FALSE;
     }
 
+    if ((ULONG)FileInformationClass == LDK_FILE_IO_PRIORITY_HINT_INFO) {
+        PFILE_IO_PRIORITY_HINT_INFO PriorityInfo;
+        FILE_IO_PRIORITY_HINT_INFORMATION NativePriorityInfo;
+
+        if (dwBufferSize < sizeof(FILE_IO_PRIORITY_HINT_INFO)) {
+            SetLastError( ERROR_INSUFFICIENT_BUFFER );
+            return FALSE;
+        }
+
+        PriorityInfo = (PFILE_IO_PRIORITY_HINT_INFO)lpFileInformation;
+        if (PriorityInfo->PriorityHint < IoPriorityHintVeryLow ||
+            PriorityInfo->PriorityHint >= MaximumIoPriorityHintType) {
+            SetLastError( ERROR_INVALID_PARAMETER );
+            return FALSE;
+        }
+
+        NativePriorityInfo.PriorityHint = (IO_PRIORITY_HINT)PriorityInfo->PriorityHint;
+        Status = ZwSetInformationFile( hFile,
+                                       &IoStatus,
+                                       &NativePriorityInfo,
+                                       sizeof(NativePriorityInfo),
+                                       FileIoPriorityHintInformation );
+        if (NT_SUCCESS(Status)) {
+            return TRUE;
+        }
+
+        LdkSetLastNTError( Status );
+        return FALSE;
+    }
+
     if (FileInformationClass == FileDispositionInfo) {
         PFILE_DISPOSITION_INFO DispositionInfo;
         FILE_DISPOSITION_INFORMATION NativeDispositionInfo;

--- a/test/kernel32/file.c
+++ b/test/kernel32/file.c
@@ -857,6 +857,43 @@ AfterSymlinkTest:
     }
     printf("[Success] Test SetFileInformationByHandle(FileAllocationInfo)\n\n");
 
+    printf("Test SetFileInformationByHandle(FileIoPriorityHintInfo)\n");
+    DeleteFileW( L"TestIoPriority.tmp" );
+    hFile = CreateFileW( L"TestIoPriority.tmp",
+                         GENERIC_READ | GENERIC_WRITE,
+                         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                         NULL,
+                         CREATE_ALWAYS,
+                         FILE_ATTRIBUTE_NORMAL,
+                         NULL );
+    if (hFile == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileIoPriorityHintInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    /* Windows validates this buffer with pointer-size alignment on x64. */
+    ULONGLONG PriorityHintInfoStorage[(sizeof(FILE_IO_PRIORITY_HINT_INFO) +
+                                       sizeof(ULONGLONG) - 1) /
+                                      sizeof(ULONGLONG)];
+    PFILE_IO_PRIORITY_HINT_INFO PriorityHintInfo =
+        (PFILE_IO_PRIORITY_HINT_INFO)PriorityHintInfoStorage;
+    RtlZeroMemory( PriorityHintInfoStorage,
+                   sizeof(PriorityHintInfoStorage) );
+    PriorityHintInfo->PriorityHint = IoPriorityHintNormal;
+    rv = SetFileInformationByHandle( hFile,
+                                     FileIoPriorityHintInfo,
+                                     PriorityHintInfo,
+                                     sizeof(*PriorityHintInfo) );
+    CloseHandle( hFile );
+    if (!rv) {
+        fprintf(stderr, "[Failed] ErrorCode = %d\n", GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileIoPriorityHintInfo)\n\n");
+        goto DeleteTest;
+    }
+    printf("[Success] Test SetFileInformationByHandle(FileIoPriorityHintInfo)\n\n");
+
     printf("Test SetFileInformationByHandle(FileRenameInfo)\n");
     DeleteFileW( L"TestRenameSource.tmp" );
     DeleteFileW( L"TestRenameTarget.tmp" );
@@ -1035,6 +1072,7 @@ AfterSymlinkTest:
 
 DeleteTest:
     DeleteFileW( L"TestAllocation.tmp" );
+    DeleteFileW( L"TestIoPriority.tmp" );
     DeleteFileW( L"TestRenameSource.tmp" );
     DeleteFileW( L"TestRenameTarget.tmp" );
     DeleteFileW( L"TestRenameExSource.tmp" );


### PR DESCRIPTION
﻿## Summary
- add `PRIORITY_HINT` and `FILE_IO_PRIORITY_HINT_INFO` to the public Win32-compatible headers
- implement `SetFileInformationByHandle(FileIoPriorityHintInfo)` through `ZwSetInformationFile(FileIoPriorityHintInformation)`
- cover the class in FileTest and document it in the file/handle API notes

## Validation
- built `LdkTest` x64 Debug
- built `LdkTest` x86 Debug
- ran `LdkWin32ApiTest.exe FileTest` for x64 Debug
- ran `LdkWin32ApiTest.exe FileTest` for x86 Debug
- loaded the x64 `LdkTest` driver in the VM as service `LdkTest`; `sc start` returned `0` and the service stayed `RUNNING`

## Notes
Windows x64 rejects a misaligned `FileIoPriorityHintInfo` buffer with `ERROR_NOACCESS`, so the shared FileTest uses pointer-size-aligned storage for this case.
