### PR TITLE
Support file remote protocol info

### DIFF
--- a/docs/api/file-and-handles.md
+++ b/docs/api/file-and-handles.md
@@ -31,6 +31,7 @@ attribute helpers are backed by native file information queries and setters.
 - `FileStreamInfo`
 - `FileCompressionInfo`
 - `FileAttributeTagInfo`
+- `FileRemoteProtocolInfo`
 - `FileStorageInfo`
 - `FileAlignmentInfo`
 - `FileIdInfo`
@@ -39,6 +40,11 @@ attribute helpers are backed by native file information queries and setters.
 `FileFsSectorSizeInformation` volume query and reports the logical sector,
 physical sector, effective physical sector, alignment offsets, and storage
 alignment flags exposed by the underlying file system stack.
+
+`FileRemoteProtocolInfo` forwards to the native
+`FileRemoteProtocolInformation` query. Local file systems normally reject that
+query with `ERROR_INVALID_PARAMETER`; remote or network file systems may return
+protocol details when the underlying file system supports the native class.
 
 `SetFileInformationByHandle` currently supports:
 

--- a/include/Ldk/winbase.h
+++ b/include/Ldk/winbase.h
@@ -275,6 +275,64 @@ typedef struct _FILE_STORAGE_INFO {
     ULONG ByteOffsetForPartitionAlignment;
 } FILE_STORAGE_INFO, *PFILE_STORAGE_INFO;
 
+#ifndef REMOTE_PROTOCOL_INFO_FLAG_LOOPBACK
+#define REMOTE_PROTOCOL_INFO_FLAG_LOOPBACK              0x00000001
+#define REMOTE_PROTOCOL_INFO_FLAG_OFFLINE               0x00000002
+#define REMOTE_PROTOCOL_INFO_FLAG_PERSISTENT_HANDLE     0x00000004
+#endif
+
+#ifndef RPI_FLAG_SMB2_SHARECAP_TIMEWARP
+#define RPI_FLAG_SMB2_SHARECAP_TIMEWARP                0x00000002
+#define RPI_FLAG_SMB2_SHARECAP_DFS                     0x00000008
+#define RPI_FLAG_SMB2_SHARECAP_CONTINUOUS_AVAILABILITY 0x00000010
+#define RPI_FLAG_SMB2_SHARECAP_SCALEOUT                0x00000020
+#define RPI_FLAG_SMB2_SHARECAP_CLUSTER                 0x00000040
+#endif
+
+#ifndef RPI_SMB2_SHAREFLAG_ENCRYPT_DATA
+#define RPI_SMB2_SHAREFLAG_ENCRYPT_DATA                0x00000001
+#define RPI_SMB2_SHAREFLAG_COMPRESS_DATA               0x00000002
+#endif
+
+#ifndef RPI_SMB2_FLAG_SERVERCAP_DFS
+#define RPI_SMB2_FLAG_SERVERCAP_DFS                    0x00000001
+#define RPI_SMB2_FLAG_SERVERCAP_LEASING                0x00000002
+#define RPI_SMB2_FLAG_SERVERCAP_LARGEMTU               0x00000004
+#define RPI_SMB2_FLAG_SERVERCAP_MULTICHANNEL           0x00000008
+#define RPI_SMB2_FLAG_SERVERCAP_PERSISTENT_HANDLES     0x00000010
+#define RPI_SMB2_FLAG_SERVERCAP_DIRECTORY_LEASING      0x00000020
+#endif
+
+typedef struct _FILE_REMOTE_PROTOCOL_INFO {
+    USHORT StructureVersion;
+    USHORT StructureSize;
+    ULONG Protocol;
+    USHORT ProtocolMajorVersion;
+    USHORT ProtocolMinorVersion;
+    USHORT ProtocolRevision;
+    USHORT Reserved;
+    ULONG Flags;
+    struct {
+        ULONG Reserved[8];
+    } GenericReserved;
+    union {
+        struct {
+            struct {
+                ULONG Capabilities;
+            } Server;
+            struct {
+                ULONG Capabilities;
+#if defined(NTDDI_WIN10_NI) && (NTDDI_VERSION >= NTDDI_WIN10_NI)
+                ULONG ShareFlags;
+#else
+                ULONG CachingFlags;
+#endif
+            } Share;
+        } Smb2;
+        ULONG Reserved[16];
+    } ProtocolSpecific;
+} FILE_REMOTE_PROTOCOL_INFO, *PFILE_REMOTE_PROTOCOL_INFO;
+
 #ifndef FileBasicInfo
 #define FileBasicInfo ((FILE_INFO_BY_HANDLE_CLASS)0)
 #endif
@@ -304,6 +362,9 @@ typedef struct _FILE_STORAGE_INFO {
 #endif
 #ifndef FileAttributeTagInfo
 #define FileAttributeTagInfo ((FILE_INFO_BY_HANDLE_CLASS)9)
+#endif
+#ifndef FileRemoteProtocolInfo
+#define FileRemoteProtocolInfo ((FILE_INFO_BY_HANDLE_CLASS)13)
 #endif
 #ifndef FileStorageInfo
 #define FileStorageInfo ((FILE_INFO_BY_HANDLE_CLASS)16)

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -2743,6 +2743,28 @@ GetFileInformationByHandleEx (
         return TRUE;
     }
 
+    if ((ULONG)FileInformationClass == LDK_FILE_REMOTE_PROTOCOL_INFO) {
+        IO_STATUS_BLOCK IoStatus;
+        NTSTATUS Status;
+
+        if (dwBufferSize < sizeof(FILE_REMOTE_PROTOCOL_INFO)) {
+            SetLastError( ERROR_BAD_LENGTH );
+            return FALSE;
+        }
+
+        Status = ZwQueryInformationFile( hFile,
+                                         &IoStatus,
+                                         lpFileInformation,
+                                         dwBufferSize,
+                                         FileRemoteProtocolInformation );
+        if (! NT_SUCCESS(Status)) {
+            LdkSetLastNTError( Status );
+            return FALSE;
+        }
+
+        return TRUE;
+    }
+
     if (! GetFileInformationByHandle( hFile,
                                       &HandleInfo )) {
         return FALSE;

--- a/test/kernel32/file.c
+++ b/test/kernel32/file.c
@@ -378,7 +378,7 @@ FileTest (
     }
     printf("[Success] Test GetFileInformationByHandleEx(FileStreamInfo)\n\n");
 
-    printf("Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n");
+    printf("Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n");
     FILE_COMPRESSION_INFO CompressionInfo;
     RtlZeroMemory( &CompressionInfo,
                    sizeof(CompressionInfo) );
@@ -390,7 +390,7 @@ FileTest (
                 "[Failed] GetFileInformationByHandleEx(FileCompressionInfo) ErrorCode = %d\n",
                 GetLastError());
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -398,7 +398,7 @@ FileTest (
         fprintf(stderr,
                 "[Failed] FileCompressionInfo returned negative compressed size\n");
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -414,7 +414,7 @@ FileTest (
                 "[Failed] GetFileInformationByHandleEx(FileAlignmentInfo) ErrorCode = %d\n",
                 GetLastError());
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -424,7 +424,7 @@ FileTest (
                 "[Failed] FileAlignmentInfo returned unexpected alignment mask = %lu\n",
                 AlignmentInfo.AlignmentRequirement);
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -440,7 +440,7 @@ FileTest (
                 "[Failed] GetFileInformationByHandleEx(FileStorageInfo) ErrorCode = %d\n",
                 GetLastError());
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
@@ -455,11 +455,59 @@ FileTest (
                 StorageInfo.PhysicalBytesPerSectorForPerformance,
                 StorageInfo.FileSystemEffectivePhysicalBytesPerSectorForAtomicity);
         CloseHandle( hFile );
-        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
         rv = FALSE;
         goto DeleteTest;
     }
-    printf("[Success] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo)\n\n");
+
+    FILE_REMOTE_PROTOCOL_INFO RemoteProtocolInfo;
+    RtlZeroMemory( &RemoteProtocolInfo,
+                   sizeof(RemoteProtocolInfo) );
+    SetLastError( ERROR_SUCCESS );
+    BOOL RemoteProtocolResult =
+        GetFileInformationByHandleEx( hFile,
+                                      FileRemoteProtocolInfo,
+                                      &RemoteProtocolInfo,
+                                      sizeof(RemoteProtocolInfo) );
+    if (RemoteProtocolResult) {
+        if (RemoteProtocolInfo.StructureVersion == 0 ||
+            RemoteProtocolInfo.StructureSize > sizeof(RemoteProtocolInfo)) {
+            fprintf(stderr,
+                    "[Failed] FileRemoteProtocolInfo returned invalid header Version = %hu Size = %hu\n",
+                    RemoteProtocolInfo.StructureVersion,
+                    RemoteProtocolInfo.StructureSize);
+            CloseHandle( hFile );
+            printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
+            rv = FALSE;
+            goto DeleteTest;
+        }
+    } else if (GetLastError() != ERROR_INVALID_PARAMETER) {
+        fprintf(stderr,
+                "[Failed] FileRemoteProtocolInfo ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    SetLastError( ERROR_SUCCESS );
+    if (GetFileInformationByHandleEx( hFile,
+                                      FileRemoteProtocolInfo,
+                                      &RemoteProtocolInfo,
+                                      FIELD_OFFSET(FILE_REMOTE_PROTOCOL_INFO,
+                                                   GenericReserved) ) ||
+        GetLastError() != ERROR_BAD_LENGTH) {
+        fprintf(stderr,
+                "[Failed] FileRemoteProtocolInfo short buffer ErrorCode = %d\n",
+                GetLastError());
+        CloseHandle( hFile );
+        printf("[Failed] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    printf("[Success] Test GetFileInformationByHandleEx(FileCompressionInfo / FileAlignmentInfo / FileStorageInfo / FileRemoteProtocolInfo)\n\n");
     CloseHandle( hFile );
     if (!rv || HandleInfo.nNumberOfLinks < 2) {
         fprintf(stderr,


### PR DESCRIPTION
﻿## Summary
- add the `FILE_REMOTE_PROTOCOL_INFO` layout and related constants to the Win32-compatible headers
- implement `GetFileInformationByHandleEx(FileRemoteProtocolInfo)` by forwarding to `ZwQueryInformationFile(FileRemoteProtocolInformation)`
- cover local-file failure and short-buffer behavior in the shared FileTest
- document the supported query class and local-file `ERROR_INVALID_PARAMETER` behavior

## Validation
- built `LdkTest` x64 Debug
- built `LdkTest` x86 Debug
- ran `LdkWin32ApiTest.exe FileTest` for x64 Debug
- ran `LdkWin32ApiTest.exe FileTest` for x86 Debug
- loaded the x64 `LdkTest` driver in the VM as service `LdkTest`; kernel log reached `[LdkTest] PASS all tests`
