### PR TITLE
Support file case sensitivity info

### DIFF
--- a/docs/api/file-and-handles.md
+++ b/docs/api/file-and-handles.md
@@ -54,8 +54,15 @@ protocol details when the underlying file system supports the native class.
 - `FileAllocationInfo`
 - `FileEndOfFileInfo`
 - `FileIoPriorityHintInfo`
+- `FileCaseSensitiveInfo`
 - `FileDispositionInfo`
 - `FileDispositionInfoEx`
+
+`FileCaseSensitiveInfo` is passed through to the native
+`FileCaseSensitiveInformation` setter. The underlying file system and security
+policy decide whether enabling or disabling per-directory case sensitivity is
+allowed. LDK validates the short-buffer case to match Win32's
+`ERROR_BAD_LENGTH` behavior and otherwise preserves the native result.
 
 The fallback behavior intentionally distinguishes invalid input from missing
 LDK coverage:

--- a/include/Ldk/winbase.h
+++ b/include/Ldk/winbase.h
@@ -232,6 +232,14 @@ typedef struct _FILE_IO_PRIORITY_HINT_INFO {
     PRIORITY_HINT PriorityHint;
 } FILE_IO_PRIORITY_HINT_INFO, *PFILE_IO_PRIORITY_HINT_INFO;
 
+#ifndef FILE_CS_FLAG_CASE_SENSITIVE_DIR
+#define FILE_CS_FLAG_CASE_SENSITIVE_DIR 0x00000001
+#endif
+
+typedef struct _FILE_CASE_SENSITIVE_INFO {
+    ULONG Flags;
+} FILE_CASE_SENSITIVE_INFO, *PFILE_CASE_SENSITIVE_INFO;
+
 typedef struct _FILE_STREAM_INFO {
     DWORD NextEntryOffset;
     DWORD StreamNameLength;
@@ -391,6 +399,9 @@ typedef struct _FILE_REMOTE_PROTOCOL_INFO {
 #endif
 #ifndef FileRenameInfoEx
 #define FileRenameInfoEx ((FILE_INFO_BY_HANDLE_CLASS)22)
+#endif
+#ifndef FileCaseSensitiveInfo
+#define FileCaseSensitiveInfo ((FILE_INFO_BY_HANDLE_CLASS)23)
 #endif
 #ifndef FileNormalizedNameInfo
 #define FileNormalizedNameInfo ((FILE_INFO_BY_HANDLE_CLASS)24)

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -3123,6 +3123,30 @@ SetFileInformationByHandle (
         return FALSE;
     }
 
+    if ((ULONG)FileInformationClass == LDK_FILE_CASE_SENSITIVE_INFO) {
+        if (dwBufferSize < sizeof(FILE_CASE_SENSITIVE_INFO)) {
+            SetLastError( ERROR_BAD_LENGTH );
+            return FALSE;
+        }
+
+        if (lpFileInformation == NULL) {
+            SetLastError( ERROR_NOACCESS );
+            return FALSE;
+        }
+
+        Status = ZwSetInformationFile( hFile,
+                                       &IoStatus,
+                                       lpFileInformation,
+                                       dwBufferSize,
+                                       FileCaseSensitiveInformation );
+        if (NT_SUCCESS(Status)) {
+            return TRUE;
+        }
+
+        LdkSetLastNTError( Status );
+        return FALSE;
+    }
+
     if (FileInformationClass == FileDispositionInfo) {
         PFILE_DISPOSITION_INFO DispositionInfo;
         FILE_DISPOSITION_INFORMATION NativeDispositionInfo;

--- a/test/kernel32/file.c
+++ b/test/kernel32/file.c
@@ -942,6 +942,51 @@ AfterSymlinkTest:
     }
     printf("[Success] Test SetFileInformationByHandle(FileIoPriorityHintInfo)\n\n");
 
+    printf("Test SetFileInformationByHandle(FileCaseSensitiveInfo)\n");
+    RemoveDirectoryW( L"TestCaseSensitiveDir" );
+    if (! CreateDirectoryW( L"TestCaseSensitiveDir", NULL )) {
+        fprintf(stderr, "[Failed] CreateDirectoryW(TestCaseSensitiveDir) ErrorCode = %d\n",
+                GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileCaseSensitiveInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    HANDLE hDirectory = CreateFileW( L"TestCaseSensitiveDir",
+                                     FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES,
+                                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                     NULL,
+                                     OPEN_EXISTING,
+                                     FILE_FLAG_BACKUP_SEMANTICS,
+                                     NULL );
+    if (hDirectory == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "[Failed] Open TestCaseSensitiveDir ErrorCode = %d\n",
+                GetLastError());
+        printf("[Failed] Test SetFileInformationByHandle(FileCaseSensitiveInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+
+    FILE_CASE_SENSITIVE_INFO CaseSensitiveInfo;
+    CaseSensitiveInfo.Flags = 0;
+    rv = SetFileInformationByHandle( hDirectory,
+                                     FileCaseSensitiveInfo,
+                                     &CaseSensitiveInfo,
+                                     sizeof(CaseSensitiveInfo) - 1 );
+    DWORD CaseSensitiveError = GetLastError();
+    CloseHandle( hDirectory );
+    if (rv || CaseSensitiveError != ERROR_BAD_LENGTH) {
+        fprintf(stderr,
+                "[Failed] FileCaseSensitiveInfo short buffer rv = %d ErrorCode = %d\n",
+                rv,
+                CaseSensitiveError);
+        printf("[Failed] Test SetFileInformationByHandle(FileCaseSensitiveInfo)\n\n");
+        rv = FALSE;
+        goto DeleteTest;
+    }
+    rv = TRUE;
+    printf("[Success] Test SetFileInformationByHandle(FileCaseSensitiveInfo)\n\n");
+
     printf("Test SetFileInformationByHandle(FileRenameInfo)\n");
     DeleteFileW( L"TestRenameSource.tmp" );
     DeleteFileW( L"TestRenameTarget.tmp" );
@@ -1126,6 +1171,7 @@ DeleteTest:
     DeleteFileW( L"TestRenameExSource.tmp" );
     DeleteFileW( L"TestRenameExTarget.tmp" );
     DeleteFileW( L"TestDisposition.tmp" );
+    RemoveDirectoryW( L"TestCaseSensitiveDir" );
     DeleteFileW( L"TestMoved.tmp" );
     DeleteFileW( L"TestCopy.tmp" );
     DeleteFileW( L"TestHardLink.tmp" );


### PR DESCRIPTION
﻿## Summary
- add the Win32 `FILE_CASE_SENSITIVE_INFO` layout and `FileCaseSensitiveInfo` fallback constant
- route `SetFileInformationByHandle(FileCaseSensitiveInfo)` to native `FileCaseSensitiveInformation`
- cover the Win32 short-buffer behavior in `FileTest` and document the supported class

## Validation
- `cmake --build test\build_x64 --config Debug --target LdkTest`
- `cmake --build test\build_x86 --config Debug --target LdkTest`
- `artifacts\build\win32-api-x64\bin\Debug\LdkWin32ApiTest.exe FileTest`
- `artifacts\build\win32-api-x86\bin\Debug\LdkWin32ApiTest.exe FileTest`
- `cmake --build build_ARM --config Debug`
- `cmake --build build_ARM64 --config Debug`
- VM load/unload test with service `LdkTest`: `start_rc=0`, service reached `RUNNING`, cleanup `stop_rc=0`, `delete_rc=0`
