### PR TITLE
Avoid FILE_STAT_BASIC_INFORMATION redefinition

### DIFF
--- a/include/Ldk/winnt.h
+++ b/include/Ldk/winnt.h
@@ -200,26 +200,6 @@ VOID
     _In_ ULONG_PTR Parameter
     );
 
-#if !defined(NTDDI_WIN11_ZN) || (NTDDI_VERSION < NTDDI_WIN11_ZN)
-typedef struct _FILE_STAT_BASIC_INFORMATION {
-    LARGE_INTEGER FileId;
-    LARGE_INTEGER CreationTime;
-    LARGE_INTEGER LastAccessTime;
-    LARGE_INTEGER LastWriteTime;
-    LARGE_INTEGER ChangeTime;
-    LARGE_INTEGER AllocationSize;
-    LARGE_INTEGER EndOfFile;
-    DWORD FileAttributes;
-    DWORD ReparseTag;
-    DWORD NumberOfLinks;
-    DWORD DeviceType;
-    DWORD DeviceCharacteristics;
-    DWORD Reserved;
-    LARGE_INTEGER VolumeSerialNumber;
-    FILE_ID_128 FileId128;
-} FILE_STAT_BASIC_INFORMATION, *PFILE_STAT_BASIC_INFORMATION;
-#endif
-
 typedef LONG (NTAPI *PVECTORED_EXCEPTION_HANDLER)(
     struct _EXCEPTION_POINTERS *ExceptionInfo
     );

--- a/src/kernel32/fileapi.c
+++ b/src/kernel32/fileapi.c
@@ -3639,10 +3639,28 @@ LdkpFillFileStatLxInformation (
     StatLxInfo->NumberOfLinks = StandardInfo->NumberOfLinks;
 }
 
+typedef struct _LDK_FILE_STAT_BASIC_INFORMATION {
+    LARGE_INTEGER FileId;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    LARGE_INTEGER AllocationSize;
+    LARGE_INTEGER EndOfFile;
+    DWORD FileAttributes;
+    DWORD ReparseTag;
+    DWORD NumberOfLinks;
+    DWORD DeviceType;
+    DWORD DeviceCharacteristics;
+    DWORD Reserved;
+    LARGE_INTEGER VolumeSerialNumber;
+    FILE_ID_128 FileId128;
+} LDK_FILE_STAT_BASIC_INFORMATION, *PLDK_FILE_STAT_BASIC_INFORMATION;
+
 static
 VOID
 LdkpFillFileStatBasicInformation (
-    _Out_ PFILE_STAT_BASIC_INFORMATION StatBasicInfo,
+    _Out_ PLDK_FILE_STAT_BASIC_INFORMATION StatBasicInfo,
     _In_ HANDLE FileHandle,
     _In_ const BY_HANDLE_FILE_INFORMATION *HandleInfo,
     _In_ const FILE_BASIC_INFO *BasicInfo,
@@ -3798,12 +3816,12 @@ GetFileInformationByName (
         break;
 
     case FileStatBasicByNameInfo:
-        if (FileInfoBufferSize < sizeof(FILE_STAT_BASIC_INFORMATION)) {
+        if (FileInfoBufferSize < sizeof(LDK_FILE_STAT_BASIC_INFORMATION)) {
             SetLastError( ERROR_INSUFFICIENT_BUFFER );
             goto Exit;
         }
 
-        LdkpFillFileStatBasicInformation( (PFILE_STAT_BASIC_INFORMATION)FileInfoBuffer,
+        LdkpFillFileStatBasicInformation( (PLDK_FILE_STAT_BASIC_INFORMATION)FileInfoBuffer,
                                           FileHandle,
                                           &HandleInfo,
                                           &BasicInfo,


### PR DESCRIPTION
## Summary
- Stop injecting the Windows SDK `FILE_STAT_BASIC_INFORMATION` typedef from LDK public `winnt.h`.
- Keep LDK `FileStatBasicByNameInfo` support by using an internal layout-compatible struct in `fileapi.c`.

## Why
WDK 10.0.26100 can provide `_FILE_STAT_BASIC_INFORMATION` from SDK headers, while older target/SDK combinations may not. A public fallback typedef in LDK `winnt.h` cannot reliably detect that state with the preprocessor and either collides with WDK 26100 or disappears for LDK's own build. Keeping the layout private avoids public header redefinition while preserving LDK's implementation path.

## Validation
- Local: `build.bat . ARM Debug` passed with VS 2022 BuildTools.
- Local: `build.bat . x64 Debug` passed with VS 2022 BuildTools.
- CI is re-running on this branch.