### PR TITLE
Fix ICU registration warning on v142

### DIFF
--- a/src/icu/icu.c
+++ b/src/icu/icu.c
@@ -478,14 +478,14 @@ LDK_FUNCTION_REGISTRATION LdkpIcuFunctionRegistration[] = {
     { "ucal_getDefaultTimeZone", LdkpIcuUcalGetDefaultTimeZone },
     { "ucal_getTimeZoneDisplayName", LdkpIcuUcalGetTimeZoneDisplayName },
     { "ucal_getTimeZoneTransitionDate", LdkpIcuUcalGetTimeZoneTransitionDate },
-    { "ucal_getTZDataVersion", LdkpIcuUcalGetTZDataVersion },
+    { "ucal_getTZDataVersion", (PVOID)LdkpIcuUcalGetTZDataVersion },
     { "ucal_inDaylightTime", LdkpIcuUcalInDaylightTime },
     { "ucal_open", LdkpIcuUcalOpen },
     { "ucal_openTimeZoneIDEnumeration", LdkpIcuUcalOpenTimeZoneIDEnumeration },
     { "ucal_setMillis", LdkpIcuUcalSetMillis },
     { "uenum_close", LdkpIcuUenumClose },
     { "uenum_count", LdkpIcuUenumCount },
-    { "uenum_unext", LdkpIcuUenumUnext },
+    { "uenum_unext", (PVOID)LdkpIcuUenumUnext },
     { NULL, NULL }
 };
 #pragma warning(default:4152)


### PR DESCRIPTION
## Summary

- Add explicit `PVOID` casts for ICU function registrations whose functions return const-qualified pointer types.
- Fix v142 `/W4 /WX` builds where MSVC emits C4090 for those registrations.

## Validation

- `git diff --check`
- Local v143 x64 Debug LDK build: `cmake --build D:\projects\ldk\build_x64_v143_icu_fix --config Debug --target Ldk --parallel`

## Notes

The function registration table intentionally stores exported function entry points as `PVOID`; the file already disables C4152 around that table for function-pointer/data-pointer registration. The explicit casts make the existing intent unambiguous to v142 as well.