### PR TITLE
Add toolset-aware NuGet packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,30 +87,47 @@ jobs:
           Write-Host "Package version: $version"
 
   build-libs:
-    name: Build NuGet libs ${{ matrix.arch }} ${{ matrix.config }}
+    name: Build NuGet libs ${{ matrix.toolset }} ${{ matrix.arch }} ${{ matrix.config }}
     needs: version
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        toolset: [v143, v145]
         arch: [x86, x64, ARM, ARM64]
         config: [Debug, Release]
+        include:
+          - toolset: v143
+            runner: windows-2022
+            windows_sdk: 10.0.22621.0
+          - toolset: v145
+            runner: windows-2025-vs2026
+            windows_sdk: 10.0.26100.0
+        exclude:
+          - toolset: v145
+            arch: ARM
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Ensure WDK
+        if: ${{ matrix.toolset == 'v145' }}
+        shell: pwsh
+        run: ./scripts/nuget/Ensure-LdkWdk.ps1 -WindowsSdkVersion '${{ matrix.windows_sdk }}'
 
       - name: Build prebuilt libraries
         shell: pwsh
         run: >
           ./scripts/nuget/Build-LdkNuGetLibs.ps1
+          -Toolset '${{ matrix.toolset }}'
           -Architecture '${{ matrix.arch }}'
           -Configuration '${{ matrix.config }}'
-          -WindowsSdkVersion '10.0.22621.0'
+          -WindowsSdkVersion '${{ matrix.windows_sdk }}'
 
       - uses: actions/upload-artifact@v7
         with:
-          name: ldk-nuget-libs-${{ matrix.arch }}-${{ matrix.config }}
-          path: artifacts/nuget-staging/lib/native/${{ matrix.arch }}/${{ matrix.config }}
+          name: ldk-nuget-libs-${{ matrix.toolset }}-${{ matrix.arch }}-${{ matrix.config }}
+          path: artifacts/nuget-staging/lib/native/${{ matrix.toolset }}/${{ matrix.arch }}/${{ matrix.config }}
           if-no-files-found: error
 
   test-win32-api-baseline:
@@ -174,51 +191,33 @@ jobs:
 
       - uses: actions/download-artifact@v7
         with:
-          name: ldk-nuget-libs-x86-Debug
-          path: artifacts/nuget-staging/lib/native/x86/Debug
+          pattern: ldk-nuget-libs-*
+          path: artifacts/downloaded-libs
 
-      - uses: actions/download-artifact@v7
-        with:
-          name: ldk-nuget-libs-x86-Release
-          path: artifacts/nuget-staging/lib/native/x86/Release
+      - name: Stage downloaded prebuilt libraries
+        shell: pwsh
+        run: |
+          $downloadRoot = Resolve-Path artifacts/downloaded-libs
+          foreach ($artifact in Get-ChildItem -Path $downloadRoot -Directory) {
+            if ($artifact.Name -notmatch '^ldk-nuget-libs-(v[0-9]+)-(.+)-(Debug|Release)$') {
+              throw "Unexpected prebuilt library artifact name: $($artifact.Name)"
+            }
 
-      - uses: actions/download-artifact@v7
-        with:
-          name: ldk-nuget-libs-x64-Debug
-          path: artifacts/nuget-staging/lib/native/x64/Debug
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ldk-nuget-libs-x64-Release
-          path: artifacts/nuget-staging/lib/native/x64/Release
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ldk-nuget-libs-ARM-Debug
-          path: artifacts/nuget-staging/lib/native/ARM/Debug
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ldk-nuget-libs-ARM-Release
-          path: artifacts/nuget-staging/lib/native/ARM/Release
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ldk-nuget-libs-ARM64-Debug
-          path: artifacts/nuget-staging/lib/native/ARM64/Debug
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ldk-nuget-libs-ARM64-Release
-          path: artifacts/nuget-staging/lib/native/ARM64/Release
+            $toolset = $Matches[1]
+            $arch = $Matches[2]
+            $config = $Matches[3]
+            $destination = Join-Path 'artifacts/nuget-staging/lib/native' "$toolset/$arch/$config"
+            New-Item -ItemType Directory -Force -Path $destination | Out-Null
+            Copy-Item -Path (Join-Path $artifact.FullName '*') -Destination $destination -Recurse -Force
+          }
 
       - name: Pack
         shell: pwsh
-        run: ./scripts/nuget/Pack-LdkNuGet.ps1 -Version '${{ steps.version.outputs.package_version }}'
+        run: ./scripts/nuget/Pack-LdkNuGet.ps1 -Version '${{ steps.version.outputs.package_version }}' -Toolset v143,v145
 
       - name: Pack GitHub release assets
         shell: pwsh
-        run: ./scripts/nuget/Pack-LdkReleaseAssets.ps1 -Version '${{ steps.version.outputs.package_version }}'
+        run: ./scripts/nuget/Pack-LdkReleaseAssets.ps1 -Version '${{ steps.version.outputs.package_version }}' -Toolset v143,v145
 
       - uses: actions/upload-artifact@v7
         with:
@@ -233,19 +232,32 @@ jobs:
           if-no-files-found: error
 
   test-package-driver:
-    name: Test NuGet driver package ${{ matrix.arch }} ${{ matrix.config }}
+    name: Test NuGet driver package ${{ matrix.toolset }} ${{ matrix.arch }} ${{ matrix.config }}
     needs: pack
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        toolset: [v143, v145]
         arch: [x64, ARM64]
         config: [Debug, Release]
+        include:
+          - toolset: v143
+            runner: windows-2022
+            windows_sdk: 10.0.22621.0
+          - toolset: v145
+            runner: windows-2025-vs2026
+            windows_sdk: 10.0.26100.0
 
     steps:
       - uses: actions/checkout@v5
 
       - uses: NuGet/setup-nuget@v2
+
+      - name: Ensure WDK
+        if: ${{ matrix.toolset == 'v145' }}
+        shell: pwsh
+        run: ./scripts/nuget/Ensure-LdkWdk.ps1 -WindowsSdkVersion '${{ matrix.windows_sdk }}'
 
       - uses: actions/download-artifact@v7
         with:
@@ -258,19 +270,68 @@ jobs:
           ./scripts/nuget/Test-LdkNuGetPackage.ps1
           -PackageDirectory artifacts/nuget
           -Version '${{ needs.pack.outputs.package_version }}'
+          -Toolset '${{ matrix.toolset }}'
           -Architecture '${{ matrix.arch }}'
           -Configuration '${{ matrix.config }}'
-          -WindowsSdkVersion '10.0.22621.0'
+          -WindowsSdkVersion '${{ matrix.windows_sdk }}'
+
+  test-package-msbuild:
+    name: Test NuGet MSBuild package ${{ matrix.toolset }} ${{ matrix.arch }} ${{ matrix.config }}
+    needs: pack
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolset: [v143, v145]
+        arch: [x64, ARM64]
+        config: [Debug, Release]
+        include:
+          - toolset: v143
+            runner: windows-2022
+            windows_sdk: 10.0.22621.0
+          - toolset: v145
+            runner: windows-2025-vs2026
+            windows_sdk: 10.0.26100.0
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: NuGet/setup-nuget@v2
+
+      - name: Ensure WDK
+        if: ${{ matrix.toolset == 'v145' }}
+        shell: pwsh
+        run: ./scripts/nuget/Ensure-LdkWdk.ps1 -WindowsSdkVersion '${{ matrix.windows_sdk }}'
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ldk-nuget-${{ needs.pack.outputs.package_version }}
+          path: artifacts/nuget
+
+      - name: Build native MSBuild consumer test driver
+        shell: pwsh
+        run: >
+          ./scripts/nuget/Test-LdkNuGetMsBuildPackage.ps1
+          -PackageDirectory artifacts/nuget
+          -Version '${{ needs.pack.outputs.package_version }}'
+          -Toolset '${{ matrix.toolset }}'
+          -Architecture '${{ matrix.arch }}'
+          -Configuration '${{ matrix.config }}'
+          -WindowsSdkVersion '${{ matrix.windows_sdk }}'
 
   test-package-layout:
-    name: Validate NuGet package layout ${{ matrix.arch }} ${{ matrix.config }}
+    name: Validate NuGet package layout ${{ matrix.toolset }} ${{ matrix.arch }} ${{ matrix.config }}
     needs: pack
     runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
+        toolset: [v143, v145]
         arch: [x86, ARM]
         config: [Debug, Release]
+        exclude:
+          - toolset: v145
+            arch: ARM
 
     steps:
       - uses: actions/checkout@v5
@@ -288,22 +349,36 @@ jobs:
           ./scripts/nuget/Test-LdkNuGetPackage.ps1
           -PackageDirectory artifacts/nuget
           -Version '${{ needs.pack.outputs.package_version }}'
+          -Toolset '${{ matrix.toolset }}'
           -Architecture '${{ matrix.arch }}'
           -Configuration '${{ matrix.config }}'
           -SkipDriverBuild
 
   test-release-prebuilt-cmake:
-    name: Test release prebuilt CMake asset ${{ matrix.arch }} ${{ matrix.config }}
+    name: Test release prebuilt CMake asset ${{ matrix.toolset }} ${{ matrix.arch }} ${{ matrix.config }}
     needs: pack
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        toolset: [v143, v145]
         arch: [x64, ARM64]
         config: [Debug, Release]
+        include:
+          - toolset: v143
+            runner: windows-2022
+            windows_sdk: 10.0.22621.0
+          - toolset: v145
+            runner: windows-2025-vs2026
+            windows_sdk: 10.0.26100.0
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Ensure WDK
+        if: ${{ matrix.toolset == 'v145' }}
+        shell: pwsh
+        run: ./scripts/nuget/Ensure-LdkWdk.ps1 -WindowsSdkVersion '${{ matrix.windows_sdk }}'
 
       - uses: actions/download-artifact@v7
         with:
@@ -316,19 +391,24 @@ jobs:
           ./scripts/nuget/Test-LdkReleaseAssets.ps1
           -ReleaseDirectory artifacts/release
           -Version '${{ needs.pack.outputs.package_version }}'
+          -Toolset '${{ matrix.toolset }}'
           -Architecture '${{ matrix.arch }}'
           -Configuration '${{ matrix.config }}'
-          -WindowsSdkVersion '10.0.22621.0'
+          -WindowsSdkVersion '${{ matrix.windows_sdk }}'
 
   test-release-prebuilt-layout:
-    name: Validate release prebuilt layout ${{ matrix.arch }} ${{ matrix.config }}
+    name: Validate release prebuilt layout ${{ matrix.toolset }} ${{ matrix.arch }} ${{ matrix.config }}
     needs: pack
     runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
+        toolset: [v143, v145]
         arch: [x86, ARM]
         config: [Debug, Release]
+        exclude:
+          - toolset: v145
+            arch: ARM
 
     steps:
       - uses: actions/checkout@v5
@@ -344,13 +424,14 @@ jobs:
           ./scripts/nuget/Test-LdkReleaseAssets.ps1
           -ReleaseDirectory artifacts/release
           -Version '${{ needs.pack.outputs.package_version }}'
+          -Toolset '${{ matrix.toolset }}'
           -Architecture '${{ matrix.arch }}'
           -Configuration '${{ matrix.config }}'
           -SkipDriverBuild
 
   publish:
     name: Publish NuGet
-    needs: [pack, test-package-driver, test-package-layout, test-win32-api-baseline]
+    needs: [pack, test-package-driver, test-package-msbuild, test-package-layout, test-win32-api-baseline]
     if: ${{ (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     runs-on: windows-2022
     permissions:
@@ -390,7 +471,7 @@ jobs:
 
   github-release:
     name: Upload GitHub Release Assets
-    needs: [pack, test-package-driver, test-package-layout, test-release-prebuilt-cmake, test-release-prebuilt-layout, test-win32-api-baseline]
+    needs: [pack, test-package-driver, test-package-msbuild, test-package-layout, test-release-prebuilt-cmake, test-release-prebuilt-layout, test-win32-api-baseline]
     if: ${{ (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.github_release) }}
     runs-on: windows-2022
     permissions:
@@ -432,7 +513,7 @@ jobs:
               "LDK $version release assets."
               ""
               "- ldk.$version.nupkg: offline NuGet package"
-              "- ldk-$version-prebuilt.zip: headers, docs, CMake helpers/package config, native MSBuild imports, and prebuilt x86/x64/ARM/ARM64 Debug/Release libraries"
+              "- ldk-$version-prebuilt.zip: headers, docs, CMake helpers/package config, native MSBuild imports, and toolset-specific prebuilt libraries (v143 x86/x64/ARM/ARM64, v145 x86/x64/ARM64)"
               "- ldk-$version-SHA256SUMS.txt: SHA-256 checksums"
             ) -join [Environment]::NewLine
             & gh release create $tagName @assets --repo $repo --target '${{ github.sha }}' --title "LDK $version" --notes $notes

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build*/
 !nuget/build/native/*.targets
 lib/
 artifacts/
+docs/analysis/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,24 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${FindWDK_SOURCE_DIR}/cmake")
 find_package(WDK REQUIRED)
 
+set(_LDK_REQUESTED_WDK_VERSION)
+foreach(_version IN ITEMS
+        "${LDK_WDK_VERSION}"
+        "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
+        "${CMAKE_SYSTEM_VERSION}")
+    if("${_LDK_REQUESTED_WDK_VERSION}" STREQUAL "" AND NOT "${_version}" STREQUAL "")
+        set(_LDK_REQUESTED_WDK_VERSION "${_version}")
+    endif()
+endforeach()
+
+if(NOT "${_LDK_REQUESTED_WDK_VERSION}" STREQUAL "" AND
+        EXISTS "${WDK_ROOT}/Include/${_LDK_REQUESTED_WDK_VERSION}/km/ntddk.h")
+    if(NOT "${WDK_VERSION}" STREQUAL "${_LDK_REQUESTED_WDK_VERSION}")
+        message(STATUS "Using WDK ${_LDK_REQUESTED_WDK_VERSION} headers for LDK")
+        set(WDK_VERSION "${_LDK_REQUESTED_WDK_VERSION}")
+    endif()
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /WX")
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,17 @@ find_package(ldk CONFIG REQUIRED PATHS "path/to/ldk-0.7.5" NO_DEFAULT_PATH)
 ldk_add_driver(MyDriver main.c)
 ```
 
-The prebuilt package contains `Ldk.lib` for x86, x64, ARM, and ARM64 Debug and
-Release builds, plus headers, docs, native MSBuild imports, and CMake helpers.
+The prebuilt package contains toolset-specific `Ldk.lib` builds under
+`lib/native/<toolset>/<arch>/<config>`, plus headers, docs, native MSBuild
+imports, and CMake helpers.
+
+Current prebuilt toolset coverage is:
+
+- `v143`: `x86`, `x64`, `ARM`, and `ARM64`
+- `v145`: `x86`, `x64`, and `ARM64`
+
+Visual Studio 2026 / v145 no longer targets 32-bit ARM, so `lib/native/v145/ARM`
+is intentionally not published.
 
 ### CMake / CPM
 
@@ -253,9 +262,11 @@ Additional implementation and test notes live under [`docs/`](docs/).
 
 ## NuGet and Releases
 
-The `Package` GitHub Actions workflow builds prebuilt x86/x64/ARM/ARM64
-Debug/Release libraries, packs the `ldk` NuGet package, validates the package
-with a minimal WDK consumer driver, and prepares GitHub Release assets.
+The `Package` GitHub Actions workflow builds prebuilt Debug/Release libraries
+under a toolset-specific package layout, packs the `ldk` NuGet package,
+validates the package with minimal WDK consumer drivers, and prepares GitHub
+Release assets. v143 packages cover x86/x64/ARM/ARM64; v145 packages cover
+x86/x64/ARM64 because Visual Studio 2026 no longer targets 32-bit ARM.
 
 The `Release` workflow is the publishing entry point. It updates
 `include/Ldk/internal/version.h`, creates a `v<version>` tag, then dispatches

--- a/cmake/Ldk.cmake
+++ b/cmake/Ldk.cmake
@@ -149,8 +149,27 @@ function(ldk_get_prebuilt_arch _out_arch)
     set(${_out_arch} "${_arch}" PARENT_SCOPE)
 endfunction()
 
+function(ldk_get_prebuilt_toolset _out_toolset)
+    if(DEFINED LDK_PREBUILT_TOOLSET AND NOT "${LDK_PREBUILT_TOOLSET}" STREQUAL "")
+        set(_toolset "${LDK_PREBUILT_TOOLSET}")
+    elseif(DEFINED MSVC_TOOLSET_VERSION AND NOT "${MSVC_TOOLSET_VERSION}" STREQUAL "")
+        set(_toolset "v${MSVC_TOOLSET_VERSION}")
+    elseif(DEFINED CMAKE_VS_PLATFORM_TOOLSET AND CMAKE_VS_PLATFORM_TOOLSET MATCHES "^v[0-9]+$")
+        set(_toolset "${CMAKE_VS_PLATFORM_TOOLSET}")
+    else()
+        message(FATAL_ERROR "Unable to determine the LDK prebuilt MSVC toolset. Set LDK_PREBUILT_TOOLSET to v143 or v145.")
+    endif()
+
+    if(NOT "${_toolset}" STREQUAL "v143" AND NOT "${_toolset}" STREQUAL "v145")
+        message(FATAL_ERROR "Unsupported LDK prebuilt MSVC toolset: ${_toolset}. Supported toolsets are v143 and v145.")
+    endif()
+
+    set(${_out_toolset} "${_toolset}" PARENT_SCOPE)
+endfunction()
+
 function(ldk_get_prebuilt_library _out_path _configuration)
     ldk_get_prebuilt_arch(_arch)
+    ldk_get_prebuilt_toolset(_toolset)
 
     if("${_configuration}" STREQUAL "Debug")
         set(_config_dir Debug)
@@ -158,14 +177,40 @@ function(ldk_get_prebuilt_library _out_path _configuration)
         set(_config_dir Release)
     endif()
 
-    set(_path "${_LDK_ROOT}/lib/native/${_arch}/${_config_dir}/Ldk.lib")
-    file(TO_CMAKE_PATH "${_path}" _path)
-    if(NOT EXISTS "${_path}")
-        set(${_out_path} "" PARENT_SCOPE)
-        return()
+    set(_has_toolset_layout OFF)
+    foreach(_known_toolset IN ITEMS v143 v145)
+        if(EXISTS "${_LDK_ROOT}/lib/native/${_known_toolset}")
+            set(_has_toolset_layout ON)
+        endif()
+    endforeach()
+
+    set(_candidate_paths
+        "${_LDK_ROOT}/lib/native/${_toolset}/${_arch}/${_config_dir}/Ldk.lib"
+    )
+
+    if(DEFINED LDK_ALLOW_PREBUILT_TOOLSET_FALLBACK AND LDK_ALLOW_PREBUILT_TOOLSET_FALLBACK)
+        if(NOT "${_toolset}" STREQUAL "v143")
+            list(APPEND _candidate_paths
+                "${_LDK_ROOT}/lib/native/v143/${_arch}/${_config_dir}/Ldk.lib"
+            )
+        endif()
     endif()
 
-    set(${_out_path} "${_path}" PARENT_SCOPE)
+    if(NOT _has_toolset_layout)
+        list(APPEND _candidate_paths
+            "${_LDK_ROOT}/lib/native/${_arch}/${_config_dir}/Ldk.lib"
+        )
+    endif()
+
+    foreach(_candidate_path IN LISTS _candidate_paths)
+        file(TO_CMAKE_PATH "${_candidate_path}" _candidate_path)
+        if(EXISTS "${_candidate_path}")
+            set(${_out_path} "${_candidate_path}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+
+    set(${_out_path} "" PARENT_SCOPE)
 endfunction()
 
 function(ldk_link_prebuilt_libraries _target)
@@ -183,7 +228,9 @@ function(ldk_link_prebuilt_libraries _target)
     elseif(_ldk_release)
         target_link_libraries(${_target} "${_ldk_release}")
     else()
-        message(FATAL_ERROR "No LDK prebuilt libraries were found under ${_LDK_ROOT}/lib/native for ${CMAKE_VS_PLATFORM_NAME}.")
+        ldk_get_prebuilt_arch(_arch)
+        ldk_get_prebuilt_toolset(_toolset)
+        message(FATAL_ERROR "No LDK prebuilt libraries were found under ${_LDK_ROOT}/lib/native for ${_toolset}/${_arch}.")
     endif()
 
     target_include_directories(${_target} PUBLIC "${_LDK_ROOT}/include")

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -64,14 +64,20 @@ driver test environment.
 
 - `include/`: public LDK headers
 - `docs/`: implementation notes
-- `lib/native/<arch>/<config>/Ldk.lib`: prebuilt static libraries
+- `lib/native/<toolset>/<arch>/<config>/Ldk.lib`: prebuilt static libraries
 - `build/native/ldk.props` and `ldk.targets`: MSBuild integration
+
+Prebuilt libraries are grouped by MSVC platform toolset, for example
+`lib/native/v143/x64/Release/Ldk.lib`.
 
 Prebuilt libraries currently target:
 
-- `x86`, `x64`, `ARM`, and `ARM64`
+- `v143`: `x86`, `x64`, `ARM`, and `ARM64`
+- `v145`: `x86`, `x64`, and `ARM64`
 - `Debug` and `Release`
-- Visual Studio 2022 with Windows SDK/WDK `10.0.22621.0`
+
+Visual Studio 2026 / v145 no longer targets 32-bit ARM, so
+`lib/native/v145/ARM` is intentionally not published.
 
 ## MSBuild usage
 

--- a/nuget/build/native/ldk.targets
+++ b/nuget/build/native/ldk.targets
@@ -10,7 +10,19 @@
     <LdkLibPlatform Condition="'$(LdkLibPlatform)' == ''">$(Platform)</LdkLibPlatform>
     <LdkLibraryConfiguration Condition="'$(LdkLibraryConfiguration)' == '' and ('$(Configuration)' == 'Debug' or '$(Configuration)' == 'Release')">$(Configuration)</LdkLibraryConfiguration>
     <LdkLibraryConfiguration Condition="'$(LdkLibraryConfiguration)' == ''">Release</LdkLibraryConfiguration>
-    <LdkLibDir Condition="'$(LdkLibDir)' == ''">$(LdkRoot)lib\native\$(LdkLibPlatform)\$(LdkLibraryConfiguration)\</LdkLibDir>
+    <LdkLibToolset Condition="'$(LdkLibToolset)' == '' and $([System.String]::Copy('$(VCToolsVersion)').StartsWith('14.5'))">v145</LdkLibToolset>
+    <LdkLibToolset Condition="'$(LdkLibToolset)' == '' and $([System.String]::Copy('$(VCToolsVersion)').StartsWith('14.4'))">v143</LdkLibToolset>
+    <LdkLibToolset Condition="'$(LdkLibToolset)' == '' and '$(PlatformToolsetVersion)' == '145'">v145</LdkLibToolset>
+    <LdkLibToolset Condition="'$(LdkLibToolset)' == '' and '$(PlatformToolsetVersion)' == '143'">v143</LdkLibToolset>
+    <LdkLibToolset Condition="'$(LdkLibToolset)' == '' and '$(PlatformToolset)' == 'v145'">v145</LdkLibToolset>
+    <LdkLibToolset Condition="'$(LdkLibToolset)' == ''">v143</LdkLibToolset>
+    <LdkAllowToolsetFallback Condition="'$(LdkAllowToolsetFallback)' == ''">false</LdkAllowToolsetFallback>
+    <LdkExactLibDir>$(LdkRoot)lib\native\$(LdkLibToolset)\$(LdkLibPlatform)\$(LdkLibraryConfiguration)\</LdkExactLibDir>
+    <LdkFallbackLibDir>$(LdkRoot)lib\native\v143\$(LdkLibPlatform)\$(LdkLibraryConfiguration)\</LdkFallbackLibDir>
+    <LdkLegacyLibDir>$(LdkRoot)lib\native\$(LdkLibPlatform)\$(LdkLibraryConfiguration)\</LdkLegacyLibDir>
+    <LdkLibDir Condition="'$(LdkLibDir)' == ''">$(LdkExactLibDir)</LdkLibDir>
+    <LdkLibDir Condition="'$(LdkUseDriverSupport)' == 'true' and '$(LdkAllowToolsetFallback)' == 'true' and '$(LdkLibToolset)' != 'v143' and !Exists('$(LdkLibDir)Ldk.lib')">$(LdkFallbackLibDir)</LdkLibDir>
+    <LdkLibDir Condition="'$(LdkUseDriverSupport)' == 'true' and !Exists('$(LdkRoot)lib\native\v143\') and !Exists('$(LdkRoot)lib\native\v145\') and Exists('$(LdkLegacyLibDir)Ldk.lib')">$(LdkLegacyLibDir)</LdkLibDir>
     <LdkUseDriverEntry Condition="'$(LdkUseDriverEntry)' == ''">true</LdkUseDriverEntry>
     <LdkDriverPreprocessorDefinitions Condition="'$(LdkDriverPreprocessorDefinitions)' == ''">_KERNEL32_</LdkDriverPreprocessorDefinitions>
   </PropertyGroup>
@@ -20,12 +32,19 @@
       Condition="'$(LdkUseDriverSupport)' == 'true' and '$(LdkLibPlatform)' != 'x86' and '$(LdkLibPlatform)' != 'x64' and '$(LdkLibPlatform)' != 'ARM' and '$(LdkLibPlatform)' != 'ARM64'"
       Text="LDK NuGet package contains prebuilt driver libraries for x86, x64, ARM, and ARM64 only. Current platform is '$(Platform)'." />
     <Error
+      Condition="'$(LdkUseDriverSupport)' == 'true' and '$(LdkExpectedLibToolset)' != '' and '$(LdkLibToolset)' != '$(LdkExpectedLibToolset)'"
+      Text="LDK selected MSVC toolset '$(LdkLibToolset)', but the consumer expected '$(LdkExpectedLibToolset)'." />
+    <Error
       Condition="'$(LdkUseDriverSupport)' == 'true' and !Exists('$(LdkLibDir)Ldk.lib')"
-      Text="Ldk.lib was not found under '$(LdkLibDir)'." />
+      Text="Ldk.lib was not found under '$(LdkLibDir)' for MSVC toolset '$(LdkLibToolset)'. Install a package that contains lib\native\$(LdkLibToolset)\$(LdkLibPlatform)\$(LdkLibraryConfiguration), or set LdkLibToolset explicitly." />
     <Message
       Importance="high"
       Condition="'$(LdkUseDriverSupport)' != 'true'"
       Text="LDK NuGet package is not applying driver link settings because LdkUseDriverSupport is '$(LdkUseDriverSupport)'." />
+    <Message
+      Importance="high"
+      Condition="'$(LdkUseDriverSupport)' == 'true'"
+      Text="LDK NuGet package selected $(LdkLibDir) for MSVC toolset $(LdkLibToolset)." />
   </Target>
 
   <ItemDefinitionGroup>

--- a/nuget/ldk.nuspec
+++ b/nuget/ldk.nuspec
@@ -20,7 +20,7 @@
     <file src="README.md" target="README.md" />
     <file src="..\LICENSE" target="LICENSE" />
     <file src="..\cmake\**\*" target="cmake" />
-    <file src="..\docs\**\*" target="docs" />
+    <file src="..\docs\**\*" target="docs" exclude="..\docs\analysis\**\*" />
     <file src="..\include\**\*" target="include" />
     <file src="..\artifacts\nuget-staging\lib\native\**\*" target="lib\native" />
 

--- a/scripts/nuget/Build-LdkNuGetLibs.ps1
+++ b/scripts/nuget/Build-LdkNuGetLibs.ps1
@@ -2,6 +2,8 @@ param(
   [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
   [string[]] $Architecture = @('x86', 'x64', 'ARM', 'ARM64'),
 
+  [string[]] $Toolset = @('v143'),
+
   [ValidateSet('Debug', 'Release')]
   [string[]] $Configuration = @('Debug', 'Release'),
 
@@ -18,6 +20,21 @@ if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
   $OutputDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
 }
 
+$Toolset = @(
+  $Toolset |
+    ForEach-Object { $_ -split ',' } |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+)
+if ($Toolset.Count -eq 0) {
+  throw "At least one LDK prebuilt MSVC toolset must be specified."
+}
+foreach ($selectedToolset in $Toolset) {
+  if ($selectedToolset -ne 'v143' -and $selectedToolset -ne 'v145') {
+    throw "Unsupported LDK prebuilt MSVC toolset: $selectedToolset. Supported toolsets are v143 and v145."
+  }
+}
+
 $platformByArchitecture = @{
   x86 = 'Win32'
   x64 = 'x64'
@@ -25,8 +42,36 @@ $platformByArchitecture = @{
   ARM64 = 'ARM64'
 }
 
-foreach ($arch in $Architecture) {
-  foreach ($config in $Configuration) {
+$generatorByToolset = @{
+  v143 = 'Visual Studio 17 2022'
+  v145 = 'Visual Studio 18 2026'
+}
+
+function Test-LdkToolsetArchitecture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $MsvcToolset,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Architecture
+  )
+
+  return -not ($MsvcToolset -eq 'v145' -and $Architecture -eq 'ARM')
+}
+
+foreach ($selectedToolset in $Toolset) {
+  foreach ($arch in $Architecture) {
+    if (-not (Test-LdkToolsetArchitecture -MsvcToolset $selectedToolset -Architecture $arch)) {
+      $message = "Visual Studio 18 2026 / v145 does not support the 32-bit ARM target platform. Build ARM with v143, or omit ARM when staging v145 libraries."
+      if ($Toolset.Count -eq 1 -and $Architecture.Count -eq 1) {
+        throw $message
+      }
+
+      Write-Warning "$message Skipping $selectedToolset $arch."
+      continue
+    }
+
+    foreach ($config in $Configuration) {
     $platform = $platformByArchitecture[$arch]
     if ($arch -eq 'ARM') {
       # Windows SDK 10.0.26100.0 no longer supports 32-bit ARM. Pin the
@@ -35,8 +80,8 @@ foreach ($arch in $Architecture) {
       $platform = "$platform,version=$WindowsSdkVersion"
     }
 
-    $buildDir = Join-Path $repoRoot "artifacts\build\ldk_${arch}_$config"
-    $libOutputDir = Join-Path $OutputDirectory "lib\native\$arch\$config"
+    $buildDir = Join-Path $repoRoot "artifacts\build\ldk_${selectedToolset}_${arch}_$config"
+    $libOutputDir = Join-Path $OutputDirectory "lib\native\$selectedToolset\$arch\$config"
 
     New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
     New-Item -ItemType Directory -Force -Path $libOutputDir | Out-Null
@@ -44,9 +89,10 @@ foreach ($arch in $Architecture) {
     $configureArgs = @(
       '-S', $repoRoot,
       '-B', $buildDir,
-      '-G', 'Visual Studio 17 2022',
+      '-G', $generatorByToolset[$selectedToolset],
       '-A', $platform,
       '-T', 'host=x64',
+      "-DLDK_WDK_VERSION=$WindowsSdkVersion",
       "-DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion",
       "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=$WindowsSdkVersion",
       "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM=$WindowsSdkVersion",
@@ -54,13 +100,13 @@ foreach ($arch in $Architecture) {
       '-DCMAKE_CXX_FLAGS=/MP'
     )
 
-    Write-Host "Configuring LDK $arch $config with Windows SDK $WindowsSdkVersion"
+    Write-Host "Configuring LDK $selectedToolset $arch $config with Windows SDK $WindowsSdkVersion"
     & cmake @configureArgs
     if ($LASTEXITCODE -ne 0) {
       throw "CMake configure failed with exit code $LASTEXITCODE."
     }
 
-    Write-Host "Building LDK $arch $config"
+    Write-Host "Building LDK $selectedToolset $arch $config"
     & cmake --build $buildDir --config $config --target Ldk --parallel
     if ($LASTEXITCODE -ne 0) {
       throw "CMake build failed with exit code $LASTEXITCODE."
@@ -95,5 +141,6 @@ foreach ($arch in $Architecture) {
     }
 
     Write-Host "Staged LDK library in $libOutputDir"
+    }
   }
 }

--- a/scripts/nuget/Ensure-LdkWdk.ps1
+++ b/scripts/nuget/Ensure-LdkWdk.ps1
@@ -1,0 +1,69 @@
+param(
+  [string] $WindowsSdkVersion = '10.0.26100.0'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-LdkWdkVersion {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $KitRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Version
+  )
+
+  $ntddk = Join-Path $KitRoot "Include\$Version\km\ntddk.h"
+  if (-not (Test-Path $ntddk)) {
+    return $false
+  }
+
+  foreach ($platform in @('x64', 'arm64')) {
+    $ntoskrnl = Join-Path $KitRoot "Lib\$Version\km\$platform\ntoskrnl.lib"
+    if (-not (Test-Path $ntoskrnl)) {
+      return $false
+    }
+  }
+
+  return $true
+}
+
+$kitRoots = @(
+  "${env:ProgramFiles(x86)}\Windows Kits\10",
+  "${env:ProgramFiles}\Windows Kits\10"
+) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+foreach ($kitRoot in $kitRoots) {
+  if ((Test-Path $kitRoot) -and (Test-LdkWdkVersion -KitRoot $kitRoot -Version $WindowsSdkVersion)) {
+    Write-Host "Found WDK $WindowsSdkVersion under $kitRoot."
+    return
+  }
+}
+
+if ($WindowsSdkVersion -ne '10.0.26100.0') {
+  throw "WDK $WindowsSdkVersion was not found. This helper can install WDK 10.0.26100.0 only."
+}
+
+Write-Host "WDK $WindowsSdkVersion was not found. Installing Microsoft.WindowsWDK.10.0.26100 with WinGet."
+winget install `
+  --exact `
+  --id Microsoft.WindowsWDK.10.0.26100 `
+  --source winget `
+  --silent `
+  --accept-package-agreements `
+  --accept-source-agreements `
+  --disable-interactivity
+
+if ($LASTEXITCODE -ne 0) {
+  throw "WDK installation failed with exit code $LASTEXITCODE."
+}
+
+foreach ($kitRoot in $kitRoots) {
+  if ((Test-Path $kitRoot) -and (Test-LdkWdkVersion -KitRoot $kitRoot -Version $WindowsSdkVersion)) {
+    Write-Host "Found WDK $WindowsSdkVersion under $kitRoot."
+    return
+  }
+}
+
+throw "WDK $WindowsSdkVersion was not found after installation."

--- a/scripts/nuget/Pack-LdkNuGet.ps1
+++ b/scripts/nuget/Pack-LdkNuGet.ps1
@@ -1,7 +1,12 @@
 param(
   [string] $Version,
   [string] $OutputDirectory,
-  [string] $NuGetExe
+  [string] $NuGetExe,
+
+  [string[]] $Toolset = @('v143'),
+
+  [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
+  [string[]] $Architecture = @('x86', 'x64', 'ARM', 'ARM64')
 )
 
 Set-StrictMode -Version Latest
@@ -21,15 +26,97 @@ $manifest = Join-Path $repoRoot 'nuget\ldk.nuspec'
 $stagingDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
 New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
 
-foreach ($arch in @('x86', 'x64', 'ARM', 'ARM64')) {
-  foreach ($config in @('Debug', 'Release')) {
-    $requiredPath = "lib\native\$arch\$config\Ldk.lib"
-    $fullPath = Join-Path $stagingDirectory $requiredPath
-    if (-not (Test-Path $fullPath)) {
-      throw "Required prebuilt library is missing: $fullPath. Run scripts\nuget\Build-LdkNuGetLibs.ps1 first."
+$Toolset = @(
+  $Toolset |
+    ForEach-Object { $_ -split ',' } |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+)
+if ($Toolset.Count -eq 0) {
+  throw "At least one LDK prebuilt MSVC toolset must be specified."
+}
+foreach ($selectedToolset in $Toolset) {
+  if ($selectedToolset -ne 'v143' -and $selectedToolset -ne 'v145') {
+    throw "Unsupported LDK prebuilt MSVC toolset: $selectedToolset. Supported toolsets are v143 and v145."
+  }
+}
+
+function Test-LdkToolsetArchitecture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $MsvcToolset,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Architecture
+  )
+
+  return -not ($MsvcToolset -eq 'v145' -and $Architecture -eq 'ARM')
+}
+
+function Remove-UnselectedStagedLibraries {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $NativeDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string[]] $SelectedToolsets,
+
+    [Parameter(Mandatory = $true)]
+    [string[]] $SelectedArchitectures
+  )
+
+  if (-not (Test-Path $NativeDirectory)) {
+    return
+  }
+
+  foreach ($toolsetDirectory in Get-ChildItem -Path $NativeDirectory -Directory) {
+    if ($SelectedToolsets -notcontains $toolsetDirectory.Name) {
+      Remove-Item -LiteralPath $toolsetDirectory.FullName -Recurse -Force
+      continue
+    }
+
+    foreach ($architectureDirectory in Get-ChildItem -Path $toolsetDirectory.FullName -Directory) {
+      if ($SelectedArchitectures -notcontains $architectureDirectory.Name -or
+          -not (Test-LdkToolsetArchitecture -MsvcToolset $toolsetDirectory.Name -Architecture $architectureDirectory.Name)) {
+        Remove-Item -LiteralPath $architectureDirectory.FullName -Recurse -Force
+        continue
+      }
+
+      foreach ($configurationDirectory in Get-ChildItem -Path $architectureDirectory.FullName -Directory) {
+        if ($configurationDirectory.Name -ne 'Debug' -and $configurationDirectory.Name -ne 'Release') {
+          Remove-Item -LiteralPath $configurationDirectory.FullName -Recurse -Force
+        }
+      }
     }
   }
 }
+
+foreach ($selectedToolset in $Toolset) {
+  foreach ($arch in $Architecture) {
+    if (-not (Test-LdkToolsetArchitecture -MsvcToolset $selectedToolset -Architecture $arch)) {
+      $message = "Visual Studio 18 2026 / v145 does not support the 32-bit ARM target platform."
+      if ($Toolset.Count -eq 1 -and $Architecture.Count -eq 1) {
+        throw $message
+      }
+
+      Write-Warning "$message Skipping package validation for $selectedToolset $arch."
+      continue
+    }
+
+    foreach ($config in @('Debug', 'Release')) {
+      $requiredPath = "lib\native\$selectedToolset\$arch\$config\Ldk.lib"
+      $fullPath = Join-Path $stagingDirectory $requiredPath
+      if (-not (Test-Path $fullPath)) {
+        throw "Required prebuilt library is missing: $fullPath. Run scripts\nuget\Build-LdkNuGetLibs.ps1 first."
+      }
+    }
+  }
+}
+
+Remove-UnselectedStagedLibraries `
+  -NativeDirectory (Join-Path $stagingDirectory 'lib\native') `
+  -SelectedToolsets $Toolset `
+  -SelectedArchitectures $Architecture
 
 Write-Host "Packing LDK $Version to $OutputDirectory"
 if ([string]::IsNullOrWhiteSpace($NuGetExe)) {

--- a/scripts/nuget/Pack-LdkReleaseAssets.ps1
+++ b/scripts/nuget/Pack-LdkReleaseAssets.ps1
@@ -1,6 +1,11 @@
 param(
   [string] $Version,
-  [string] $OutputDirectory
+  [string] $OutputDirectory,
+
+  [string[]] $Toolset = @('v143'),
+
+  [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
+  [string[]] $Architecture = @('x86', 'x64', 'ARM', 'ARM64')
 )
 
 Set-StrictMode -Version Latest
@@ -57,27 +62,115 @@ $checksumPath = Join-Path $OutputDirectory "ldk-$Version-SHA256SUMS.txt"
 $packagePath = Join-Path $nugetDirectory "ldk.$Version.nupkg"
 $releasePackagePath = Join-Path $OutputDirectory "ldk.$Version.nupkg"
 
+$Toolset = @(
+  $Toolset |
+    ForEach-Object { $_ -split ',' } |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+)
+if ($Toolset.Count -eq 0) {
+  throw "At least one LDK prebuilt MSVC toolset must be specified."
+}
+foreach ($selectedToolset in $Toolset) {
+  if ($selectedToolset -ne 'v143' -and $selectedToolset -ne 'v145') {
+    throw "Unsupported LDK prebuilt MSVC toolset: $selectedToolset. Supported toolsets are v143 and v145."
+  }
+}
+
 if (-not (Test-Path $packagePath)) {
   throw "NuGet package was not found: $packagePath. Run scripts\nuget\Pack-LdkNuGet.ps1 first."
 }
 
-foreach ($arch in @('x86', 'x64', 'ARM', 'ARM64')) {
-  foreach ($config in @('Debug', 'Release')) {
-    $requiredPath = Join-Path $stagingDirectory "lib\native\$arch\$config\Ldk.lib"
-    if (-not (Test-Path $requiredPath)) {
-      throw "Required prebuilt release asset file is missing: $requiredPath."
+function Test-LdkToolsetArchitecture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $MsvcToolset,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Architecture
+  )
+
+  return -not ($MsvcToolset -eq 'v145' -and $Architecture -eq 'ARM')
+}
+
+function Remove-UnselectedStagedLibraries {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $NativeDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string[]] $SelectedToolsets,
+
+    [Parameter(Mandatory = $true)]
+    [string[]] $SelectedArchitectures
+  )
+
+  if (-not (Test-Path $NativeDirectory)) {
+    return
+  }
+
+  foreach ($toolsetDirectory in Get-ChildItem -Path $NativeDirectory -Directory) {
+    if ($SelectedToolsets -notcontains $toolsetDirectory.Name) {
+      Remove-Item -LiteralPath $toolsetDirectory.FullName -Recurse -Force
+      continue
+    }
+
+    foreach ($architectureDirectory in Get-ChildItem -Path $toolsetDirectory.FullName -Directory) {
+      if ($SelectedArchitectures -notcontains $architectureDirectory.Name -or
+          -not (Test-LdkToolsetArchitecture -MsvcToolset $toolsetDirectory.Name -Architecture $architectureDirectory.Name)) {
+        Remove-Item -LiteralPath $architectureDirectory.FullName -Recurse -Force
+        continue
+      }
+
+      foreach ($configurationDirectory in Get-ChildItem -Path $architectureDirectory.FullName -Directory) {
+        if ($configurationDirectory.Name -ne 'Debug' -and $configurationDirectory.Name -ne 'Release') {
+          Remove-Item -LiteralPath $configurationDirectory.FullName -Recurse -Force
+        }
+      }
     }
   }
 }
 
+foreach ($selectedToolset in $Toolset) {
+  foreach ($arch in $Architecture) {
+    if (-not (Test-LdkToolsetArchitecture -MsvcToolset $selectedToolset -Architecture $arch)) {
+      $message = "Visual Studio 18 2026 / v145 does not support the 32-bit ARM target platform."
+      if ($Toolset.Count -eq 1 -and $Architecture.Count -eq 1) {
+        throw $message
+      }
+
+      Write-Warning "$message Skipping release asset validation for $selectedToolset $arch."
+      continue
+    }
+
+    foreach ($config in @('Debug', 'Release')) {
+      $requiredPath = Join-Path $stagingDirectory "lib\native\$selectedToolset\$arch\$config\Ldk.lib"
+      if (-not (Test-Path $requiredPath)) {
+        throw "Required prebuilt release asset file is missing: $requiredPath."
+      }
+    }
+  }
+}
+
+Remove-UnselectedStagedLibraries `
+  -NativeDirectory (Join-Path $stagingDirectory 'lib\native') `
+  -SelectedToolsets $Toolset `
+  -SelectedArchitectures $Architecture
+
 Remove-Item -Recurse -Force -Path $workDirectory -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+foreach ($stalePattern in @('ldk.*.nupkg', 'ldk-*-prebuilt.zip', 'ldk-*-SHA256SUMS.txt')) {
+  Get-ChildItem -Path $OutputDirectory -Filter $stalePattern -File -ErrorAction SilentlyContinue |
+    Remove-Item -Force
+}
+
 New-Item -ItemType Directory -Force -Path $bundleRoot | Out-Null
 New-Item -ItemType Directory -Force -Path $bundleCMakePackageDirectory | Out-Null
 
 Copy-Item -Path (Join-Path $repoRoot 'README.md') -Destination $bundleRoot -Force
 Copy-Item -Path (Join-Path $repoRoot 'LICENSE') -Destination $bundleRoot -Force
 Copy-Item -Path (Join-Path $repoRoot 'docs') -Destination (Join-Path $bundleRoot 'docs') -Recurse -Force
+Remove-Item -Path (Join-Path $bundleRoot 'docs\analysis') -Recurse -Force -ErrorAction SilentlyContinue
 Copy-Item -Path (Join-Path $repoRoot 'include') -Destination (Join-Path $bundleRoot 'include') -Recurse -Force
 Copy-Item -Path (Join-Path $repoRoot 'cmake') -Destination (Join-Path $bundleRoot 'cmake') -Recurse -Force
 Copy-Item -Path (Join-Path $repoRoot 'cmake\*') -Destination $bundleCMakePackageDirectory -Recurse -Force
@@ -125,13 +218,14 @@ Contents:
 - cmake/: CMake helpers
 - share/ldk/cmake/: CMake package config for find_package(ldk CONFIG)
 - build/native/: native MSBuild props and targets from the NuGet package
-- lib/native/: prebuilt Ldk.lib for x86, x64, ARM, and ARM64, Debug and Release
+- lib/native/<toolset>/: prebuilt Ldk.lib for x86, x64, ARM, and ARM64, Debug and Release
 - docs/: repository documentation
 
-The prebuilt driver libraries target Visual Studio 2022 and Windows SDK/WDK
-10.0.22621.0. Validate the final driver with the Windows, WDK, SDK, Visual
-Studio, architecture, Driver Verifier, and code integrity settings that you
-ship.
+The prebuilt driver libraries are grouped by MSVC platform toolset. v143
+contains x86, x64, ARM, and ARM64 libraries. v145 contains x86, x64, and
+ARM64 libraries because Visual Studio 2026 removed the 32-bit ARM target.
+Validate the final driver with the Windows, WDK, SDK, Visual Studio,
+architecture, Driver Verifier, and code integrity settings that you ship.
 "@
 Set-Content -LiteralPath (Join-Path $bundleRoot 'README.release.md') -Value $bundleReadme -Encoding UTF8
 
@@ -147,6 +241,8 @@ Get-FileHash -Algorithm SHA256 -Path $prebuiltZipPath, $releasePackagePath |
   Set-Content -LiteralPath $checksumPath -Encoding ASCII
 
 Write-Host "Created release assets:"
-Get-ChildItem -Path $OutputDirectory -File | Sort-Object FullName | ForEach-Object {
-  Write-Host "  $($_.FullName)"
+foreach ($releaseAssetPath in @($releasePackagePath, $prebuiltZipPath, $checksumPath)) {
+  if (Test-Path $releaseAssetPath) {
+    Write-Host "  $releaseAssetPath"
+  }
 }

--- a/scripts/nuget/Test-LdkNuGetMsBuildPackage.ps1
+++ b/scripts/nuget/Test-LdkNuGetMsBuildPackage.ps1
@@ -1,0 +1,461 @@
+param(
+  [string] $PackageDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [string] $Version,
+
+  [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
+  [string] $Architecture = 'x64',
+
+  [ValidateSet('v143', 'v145')]
+  [string] $Toolset = 'v143',
+
+  [ValidateSet('Debug', 'Release')]
+  [string] $Configuration = 'Debug',
+
+  [string] $WindowsSdkVersion = '10.0.22621.0',
+
+  [string] $WorkDirectory,
+
+  [string] $NuGetExe
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-XmlEscapedText {
+  param([Parameter(Mandatory = $true)][string] $Value)
+
+  return [System.Security.SecurityElement]::Escape($Value)
+}
+
+function Resolve-MsBuildPath {
+  param([Parameter(Mandatory = $true)][string] $Toolset)
+
+  $programFilesX86 = ${env:ProgramFiles(x86)}
+  $candidateRoots = @()
+  if ($Toolset -eq 'v145') {
+    $candidateRoots += Join-Path $programFilesX86 'Microsoft Visual Studio\18'
+  } else {
+    $candidateRoots += Join-Path $programFilesX86 'Microsoft Visual Studio\2022'
+  }
+
+  $candidatePaths = foreach ($root in $candidateRoots) {
+    foreach ($edition in @('Enterprise', 'Professional', 'Community', 'BuildTools')) {
+      Join-Path $root "$edition\MSBuild\Current\Bin\amd64\MSBuild.exe"
+    }
+  }
+
+  foreach ($candidatePath in $candidatePaths) {
+    if (Test-Path $candidatePath) {
+      return (Resolve-Path $candidatePath).Path
+    }
+  }
+
+  $vswhere = Join-Path $programFilesX86 'Microsoft Visual Studio\Installer\vswhere.exe'
+  if (Test-Path $vswhere) {
+    $versionRange = if ($Toolset -eq 'v145') { '[18.0,19.0)' } else { '[17.0,18.0)' }
+    $matches = @(
+      & $vswhere -products * -version $versionRange -requires Microsoft.Component.MSBuild -find 'MSBuild\Current\Bin\amd64\MSBuild.exe'
+    )
+
+    foreach ($match in $matches) {
+      if (-not [string]::IsNullOrWhiteSpace($match) -and (Test-Path $match)) {
+        return (Resolve-Path $match).Path
+      }
+    }
+  }
+
+  $pathCommand = Get-Command MSBuild.exe -ErrorAction SilentlyContinue
+  if ($pathCommand) {
+    return $pathCommand.Source
+  }
+
+  throw "MSBuild.exe for $Toolset was not found."
+}
+
+function Test-LdkWdkLayout {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $WindowsKitsRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Version,
+
+    [Parameter(Mandatory = $true)]
+    [string] $WdkLibArchitecture
+  )
+
+  $includeRoot = Join-Path $WindowsKitsRoot "Include\$Version"
+  $libDirectory = Join-Path $WindowsKitsRoot "Lib\$Version\km\$WdkLibArchitecture"
+  $requiredPaths = @(
+    (Join-Path $includeRoot 'shared\ntdef.h'),
+    (Join-Path $includeRoot 'km\ntddk.h'),
+    (Join-Path $includeRoot 'km\crt\stddef.h'),
+    (Join-Path $libDirectory 'ntoskrnl.lib'),
+    (Join-Path $libDirectory 'hal.lib'),
+    (Join-Path $libDirectory 'wmilib.lib')
+  )
+
+  foreach ($requiredPath in $requiredPaths) {
+    if (-not (Test-Path $requiredPath)) {
+      return $false
+    }
+  }
+
+  $hasSecurityRuntime = $false
+  foreach ($securityRuntime in @('BufferOverflowK.lib', 'bufferoverflowfastfailk.lib')) {
+    if (Test-Path (Join-Path $libDirectory $securityRuntime)) {
+      $hasSecurityRuntime = $true
+      break
+    }
+  }
+
+  if (-not $hasSecurityRuntime) {
+    return $false
+  }
+
+  if (($WdkLibArchitecture -eq 'arm' -or $WdkLibArchitecture -eq 'arm64') -and
+      -not (Test-Path (Join-Path $libDirectory 'libcntpr.lib'))) {
+    return $false
+  }
+
+  return $true
+}
+
+function Resolve-LdkWdkLayout {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]] $WindowsKitsRoots,
+
+    [Parameter(Mandatory = $true)]
+    [string] $PreferredVersion,
+
+    [Parameter(Mandatory = $true)]
+    [string] $WdkLibArchitecture
+  )
+
+  foreach ($windowsKitsRoot in $WindowsKitsRoots) {
+    if (-not (Test-Path $windowsKitsRoot)) {
+      continue
+    }
+
+    $candidateVersions = @()
+    if (-not [string]::IsNullOrWhiteSpace($PreferredVersion)) {
+      $candidateVersions += $PreferredVersion
+    }
+
+    $libRoot = Join-Path $windowsKitsRoot 'Lib'
+    if (Test-Path $libRoot) {
+      $candidateVersions += @(
+        Get-ChildItem -Path $libRoot -Directory |
+          Where-Object { Test-Path (Join-Path $_.FullName "km\$WdkLibArchitecture\ntoskrnl.lib") } |
+          ForEach-Object { $_.Name } |
+          Sort-Object { [version]$_ } -Descending
+      )
+    }
+
+    $candidateVersions = @($candidateVersions | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    foreach ($candidateVersion in $candidateVersions) {
+      if (Test-LdkWdkLayout -WindowsKitsRoot $windowsKitsRoot -Version $candidateVersion -WdkLibArchitecture $WdkLibArchitecture) {
+        $includeRoot = Join-Path $windowsKitsRoot "Include\$candidateVersion"
+        $libDirectory = Join-Path $windowsKitsRoot "Lib\$candidateVersion\km\$WdkLibArchitecture"
+        $securityRuntimePath = $null
+        foreach ($securityRuntime in @('BufferOverflowK.lib', 'bufferoverflowfastfailk.lib')) {
+          $candidateSecurityRuntimePath = Join-Path $libDirectory $securityRuntime
+          if (Test-Path $candidateSecurityRuntimePath) {
+            $securityRuntimePath = $candidateSecurityRuntimePath
+            break
+          }
+        }
+
+        $runtimeLibraryPaths = @($securityRuntimePath)
+        if ($WdkLibArchitecture -eq 'arm' -or $WdkLibArchitecture -eq 'arm64') {
+          $runtimeLibraryPaths += (Join-Path $libDirectory 'libcntpr.lib')
+        }
+
+        return [pscustomobject]@{
+          Version = $candidateVersion
+          IncludeRoot = $includeRoot
+          LibDirectory = $libDirectory
+          RuntimeLibraryPaths = $runtimeLibraryPaths
+        }
+      }
+    }
+  }
+
+  throw "No usable WDK layout was found for $WdkLibArchitecture. Install a WDK that contains km headers and libraries."
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
+  $PackageDirectory = Join-Path $repoRoot 'artifacts\nuget'
+}
+
+if ([string]::IsNullOrWhiteSpace($WorkDirectory)) {
+  $WorkDirectory = Join-Path $repoRoot "artifacts\nuget-msbuild-consumer-test\$Toolset\$Architecture\$Configuration"
+}
+
+if ($Toolset -eq 'v145' -and $Architecture -eq 'ARM') {
+  throw "Visual Studio 18 2026 does not provide the 32-bit ARM target in the tested Build Tools layout. Test ARM with v143, or omit ARM for v145."
+}
+
+$PackageDirectory = (Resolve-Path $PackageDirectory).Path
+$packagePath = Join-Path $PackageDirectory "ldk.$Version.nupkg"
+if (-not (Test-Path $packagePath)) {
+  throw "NuGet package was not found: $packagePath"
+}
+
+if ([string]::IsNullOrWhiteSpace($NuGetExe)) {
+  $nuget = Get-Command nuget -ErrorAction SilentlyContinue
+  if (-not $nuget) {
+    throw "nuget command was not found. Pass -NuGetExe or add nuget.exe to PATH."
+  }
+
+  $NuGetExe = $nuget.Source
+} else {
+  $NuGetExe = (Resolve-Path $NuGetExe).Path
+}
+
+$WorkDirectory = [System.IO.Path]::GetFullPath($WorkDirectory)
+$repoRootPrefix = $repoRoot.TrimEnd('\') + '\'
+if (-not $WorkDirectory.StartsWith($repoRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "WorkDirectory must be inside the repository: $repoRoot"
+}
+
+$programFilesX86 = ${env:ProgramFiles(x86)}
+$windowsKitsRoots = @(
+  (Join-Path $programFilesX86 'Windows Kits\10'),
+  (Join-Path ${env:ProgramFiles} 'Windows Kits\10')
+) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+$platformByArchitecture = @{
+  x86 = 'Win32'
+  x64 = 'x64'
+  ARM = 'ARM'
+  ARM64 = 'ARM64'
+}
+
+$wdkLibArchitectureByArchitecture = @{
+  x86 = 'x86'
+  x64 = 'x64'
+  ARM = 'arm'
+  ARM64 = 'arm64'
+}
+
+$machineByArchitecture = @{
+  x86 = 'X86'
+  x64 = 'X64'
+  ARM = 'ARM'
+  ARM64 = 'ARM64'
+}
+
+$definesByArchitecture = @{
+  x86 = 'WIN32;_X86_;i386=1;STD_CALL'
+  x64 = 'WIN32;_WIN64;_AMD64_;AMD64'
+  ARM = 'WIN32;_ARM_;ARM'
+  ARM64 = 'WIN32;_WIN64;_ARM64_;ARM64'
+}
+
+$platform = $platformByArchitecture[$Architecture]
+$wdkLibArchitecture = $wdkLibArchitectureByArchitecture[$Architecture]
+$machine = $machineByArchitecture[$Architecture]
+$architectureDefines = $definesByArchitecture[$Architecture]
+$wdkLayout = Resolve-LdkWdkLayout `
+  -WindowsKitsRoots $windowsKitsRoots `
+  -PreferredVersion $WindowsSdkVersion `
+  -WdkLibArchitecture $wdkLibArchitecture
+
+if ($wdkLayout.Version -ne $WindowsSdkVersion) {
+  Write-Host "Requested WDK $WindowsSdkVersion was not usable for $Architecture. Using WDK $($wdkLayout.Version)."
+}
+
+$WindowsSdkVersion = $wdkLayout.Version
+$wdkIncludeRoot = $wdkLayout.IncludeRoot
+$wdkLibDirectory = $wdkLayout.LibDirectory
+$msbuild = Resolve-MsBuildPath -Toolset $Toolset
+
+Remove-Item -Recurse -Force -Path $WorkDirectory -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+
+$projectDirectory = Join-Path $WorkDirectory 'consumer'
+$packagesDirectory = Join-Path $WorkDirectory 'packages'
+New-Item -ItemType Directory -Force -Path $projectDirectory | Out-Null
+
+& $NuGetExe install ldk `
+  -Version $Version `
+  -Source $PackageDirectory `
+  -OutputDirectory $packagesDirectory `
+  -NonInteractive `
+  -Verbosity detailed
+
+if ($LASTEXITCODE -ne 0) {
+  throw "nuget install failed with exit code $LASTEXITCODE."
+}
+
+$packageRoot = Join-Path $packagesDirectory "ldk.$Version"
+if (-not (Test-Path $packageRoot)) {
+  $installedPackageCandidates = @(
+    Get-ChildItem -Path $packagesDirectory -Directory |
+      Where-Object { $_.Name -like 'ldk*' } |
+      Sort-Object Name
+  )
+
+  if ($installedPackageCandidates.Count -ne 1) {
+    throw "Expected exactly one installed ldk package under '$packagesDirectory', found $($installedPackageCandidates.Count)."
+  }
+
+  $packageRoot = $installedPackageCandidates[0].FullName
+}
+
+$packageRoot = (Resolve-Path $packageRoot).Path
+
+$requiredPackagePaths = @(
+  'build\native\ldk.props',
+  'build\native\ldk.targets',
+  'include\Ldk\Windows.h',
+  "lib\native\$Toolset\$Architecture\$Configuration\Ldk.lib"
+)
+
+foreach ($requiredPackagePath in $requiredPackagePaths) {
+  $fullPath = Join-Path $packageRoot $requiredPackagePath
+  if (-not (Test-Path $fullPath)) {
+    throw "Installed package is missing expected file: $fullPath"
+  }
+}
+
+$targetName = 'LdkMsBuildPackageSmoke'
+$projectPath = Join-Path $projectDirectory "$targetName.vcxproj"
+$mainPath = Join-Path $projectDirectory 'main.c'
+
+$sharedInclude = ConvertTo-XmlEscapedText (Join-Path $wdkIncludeRoot 'shared')
+$kmInclude = ConvertTo-XmlEscapedText (Join-Path $wdkIncludeRoot 'km')
+$kmCrtInclude = ConvertTo-XmlEscapedText (Join-Path $wdkIncludeRoot 'km\crt')
+$ntoskrnlLib = ConvertTo-XmlEscapedText (Join-Path $wdkLibDirectory 'ntoskrnl.lib')
+$halLib = ConvertTo-XmlEscapedText (Join-Path $wdkLibDirectory 'hal.lib')
+$wmilibLib = ConvertTo-XmlEscapedText (Join-Path $wdkLibDirectory 'wmilib.lib')
+$runtimeLibraries = @($wdkLayout.RuntimeLibraryPaths | ForEach-Object { ConvertTo-XmlEscapedText $_ })
+$runtimeLibraryDependencies = $runtimeLibraries -join ';'
+$escapedWindowsSdkVersion = ConvertTo-XmlEscapedText $WindowsSdkVersion
+$escapedToolset = ConvertTo-XmlEscapedText $Toolset
+$escapedConfiguration = ConvertTo-XmlEscapedText $Configuration
+$escapedPlatform = ConvertTo-XmlEscapedText $platform
+$escapedArchitectureDefines = ConvertTo-XmlEscapedText $architectureDefines
+$ldkProps = ConvertTo-XmlEscapedText (Join-Path $packageRoot 'build\native\ldk.props')
+$ldkTargets = ConvertTo-XmlEscapedText (Join-Path $packageRoot 'build\native\ldk.targets')
+$runtimeLibrary = if ($Configuration -eq 'Debug') { 'MultiThreadedDebug' } else { 'MultiThreaded' }
+
+$vcxproj = @"
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="$escapedConfiguration|$escapedPlatform">
+      <Configuration>$escapedConfiguration</Configuration>
+      <Platform>$escapedPlatform</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EA955542-1D9F-4B73-9A7C-3530A7A332E3}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectName>$targetName</ProjectName>
+    <WindowsTargetPlatformVersion>$escapedWindowsSdkVersion</WindowsTargetPlatformVersion>
+    <DriverType>WDM</DriverType>
+    <LdkUseDriverSupport>true</LdkUseDriverSupport>
+    <LdkExpectedLibToolset>$escapedToolset</LdkExpectedLibToolset>
+  </PropertyGroup>
+  <Import Project="$ldkProps" Condition="Exists('$ldkProps')" />
+  <Import Project="`$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'`$(Configuration)|`$(Platform)'=='$escapedConfiguration|$escapedPlatform'">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>$escapedToolset</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="`$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <OutDir>`$(MSBuildThisFileDirectory)bin\`$(Configuration)\</OutDir>
+    <IntDir>`$(MSBuildThisFileDirectory)obj\`$(Configuration)\</IntDir>
+    <TargetName>$targetName</TargetName>
+    <TargetExt>.sys</TargetExt>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$sharedInclude;$kmInclude;$kmCrtInclude;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>$escapedArchitectureDefines;WINNT=1;_WIN32_WINNT=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>%(AdditionalOptions) /kernel</AdditionalOptions>
+      <RuntimeLibrary>$runtimeLibrary</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$ntoskrnlLib;$halLib;$wmilibLib;$runtimeLibraryDependencies;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+      <SubSystem>Native</SubSystem>
+      <AdditionalOptions>%(AdditionalOptions) /DRIVER /MACHINE:$machine</AdditionalOptions>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.c" />
+  </ItemGroup>
+  <Import Project="`$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$ldkTargets" Condition="Exists('$ldkTargets')" />
+</Project>
+"@
+
+Set-Content -LiteralPath $projectPath -Value $vcxproj -Encoding UTF8
+
+$mainC = @'
+#include <Ldk/Windows.h>
+
+DRIVER_UNLOAD DriverUnload;
+
+VOID
+DriverUnload(
+    _In_ PDRIVER_OBJECT DriverObject
+    )
+{
+    UNREFERENCED_PARAMETER(DriverObject);
+}
+
+NTSTATUS
+DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+    )
+{
+    CRITICAL_SECTION CriticalSection;
+
+    UNREFERENCED_PARAMETER(RegistryPath);
+
+    InitializeCriticalSection(&CriticalSection);
+    DeleteCriticalSection(&CriticalSection);
+
+    DriverObject->DriverUnload = DriverUnload;
+    return STATUS_SUCCESS;
+}
+'@
+
+Set-Content -LiteralPath $mainPath -Value $mainC -Encoding UTF8
+
+$msbuildArgs = @(
+  $projectPath,
+  '/m',
+  '/v:m',
+  "/p:Configuration=$Configuration",
+  "/p:Platform=$platform"
+)
+
+Write-Host "Building NuGet native MSBuild consumer for $Toolset $Architecture $Configuration"
+& $msbuild @msbuildArgs
+if ($LASTEXITCODE -ne 0) {
+  throw "MSBuild NuGet native consumer failed with exit code $LASTEXITCODE."
+}
+
+$driverPath = Join-Path $projectDirectory "bin\$Configuration\$targetName.sys"
+if (-not (Test-Path $driverPath)) {
+  throw "MSBuild NuGet native consumer driver was not produced: $driverPath"
+}
+
+Write-Host "NuGet native MSBuild consumer test passed: $driverPath"

--- a/scripts/nuget/Test-LdkNuGetPackage.ps1
+++ b/scripts/nuget/Test-LdkNuGetPackage.ps1
@@ -7,6 +7,9 @@ param(
   [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
   [string] $Architecture = 'x64',
 
+  [ValidateSet('v143', 'v145')]
+  [string] $Toolset = 'v143',
+
   [ValidateSet('Debug', 'Release')]
   [string] $Configuration = 'Release',
 
@@ -29,7 +32,7 @@ if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
 }
 
 if ([string]::IsNullOrWhiteSpace($WorkDirectory)) {
-  $WorkDirectory = Join-Path $repoRoot "artifacts\nuget-consumer-test\$Architecture\$Configuration"
+  $WorkDirectory = Join-Path $repoRoot "artifacts\nuget-consumer-test\$Toolset\$Architecture\$Configuration"
 }
 
 $WorkDirectory = [System.IO.Path]::GetFullPath($WorkDirectory)
@@ -61,6 +64,16 @@ $platformByArchitecture = @{
   ARM = 'ARM'
   ARM64 = 'ARM64'
 }
+
+$generatorByToolset = @{
+  v143 = 'Visual Studio 17 2022'
+  v145 = 'Visual Studio 18 2026'
+}
+
+if ($Toolset -eq 'v145' -and $Architecture -eq 'ARM') {
+  throw "Visual Studio 18 2026 does not provide the 32-bit ARM generator platform in the tested Build Tools layout. Test ARM with v143, or omit ARM when testing v145 libraries."
+}
+
 $platform = $platformByArchitecture[$Architecture]
 if ($Architecture -eq 'ARM') {
   # Windows SDK 10.0.26100.0 no longer supports 32-bit ARM. Pin the Visual
@@ -106,7 +119,7 @@ $requiredPackagePaths = @(
   'build\native\ldk.targets',
   'cmake\Ldk.cmake',
   'include\Ldk\Windows.h',
-  "lib\native\$Architecture\$Configuration\Ldk.lib"
+  "lib\native\$Toolset\$Architecture\$Configuration\Ldk.lib"
 )
 
 foreach ($requiredPath in $requiredPackagePaths) {
@@ -140,6 +153,7 @@ endif()
 project(ldk_nuget_package_smoke LANGUAGES C)
 
 set(LDK_ROOT "$cmakePackageRoot")
+set(LDK_PREBUILT_TOOLSET "$Toolset")
 include("$cmakePackageRoot/cmake/Ldk.cmake")
 
 ldk_add_driver(ldk_nuget_package_smoke main.c)
@@ -178,11 +192,11 @@ DriverEntry(
 '@
 Set-Content -LiteralPath (Join-Path $consumerDirectory 'main.c') -Value $mainC -Encoding UTF8
 
-$buildDirectory = Join-Path $WorkDirectory "build_$Architecture"
+$buildDirectory = Join-Path $WorkDirectory "build_${Toolset}_$Architecture"
 $configureArgs = @(
   '-S', $consumerDirectory,
   '-B', $buildDirectory,
-  '-G', 'Visual Studio 17 2022',
+  '-G', $generatorByToolset[$Toolset],
   '-A', $platform,
   '-T', 'host=x64',
   "-DLDK_WDK_VERSION=$WindowsSdkVersion",
@@ -191,13 +205,13 @@ $configureArgs = @(
   "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM=$WindowsSdkVersion"
 )
 
-Write-Host "Configuring NuGet package consumer for $Architecture $Configuration"
+Write-Host "Configuring NuGet package consumer for $Toolset $Architecture $Configuration"
 & cmake @configureArgs
 if ($LASTEXITCODE -ne 0) {
   throw "CMake configure failed with exit code $LASTEXITCODE."
 }
 
-Write-Host "Building NuGet package consumer for $Architecture $Configuration"
+Write-Host "Building NuGet package consumer for $Toolset $Architecture $Configuration"
 & cmake --build $buildDirectory --config $Configuration --target ldk_nuget_package_smoke --parallel
 if ($LASTEXITCODE -ne 0) {
   throw "CMake build failed with exit code $LASTEXITCODE."

--- a/scripts/nuget/Test-LdkReleaseAssets.ps1
+++ b/scripts/nuget/Test-LdkReleaseAssets.ps1
@@ -7,6 +7,9 @@ param(
   [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
   [string] $Architecture = 'x64',
 
+  [ValidateSet('v143', 'v145')]
+  [string] $Toolset = 'v143',
+
   [ValidateSet('Debug', 'Release')]
   [string] $Configuration = 'Release',
 
@@ -27,7 +30,7 @@ if ([string]::IsNullOrWhiteSpace($ReleaseDirectory)) {
 }
 
 if ([string]::IsNullOrWhiteSpace($WorkDirectory)) {
-  $WorkDirectory = Join-Path $repoRoot "artifacts\release-consumer-test\$Architecture\$Configuration"
+  $WorkDirectory = Join-Path $repoRoot "artifacts\release-consumer-test\$Toolset\$Architecture\$Configuration"
 }
 
 $WorkDirectory = [System.IO.Path]::GetFullPath($WorkDirectory)
@@ -48,6 +51,16 @@ $platformByArchitecture = @{
   ARM = 'ARM'
   ARM64 = 'ARM64'
 }
+
+$generatorByToolset = @{
+  v143 = 'Visual Studio 17 2022'
+  v145 = 'Visual Studio 18 2026'
+}
+
+if ($Toolset -eq 'v145' -and $Architecture -eq 'ARM') {
+  throw "Visual Studio 18 2026 does not provide the 32-bit ARM generator platform in the tested Build Tools layout. Test ARM with v143, or omit ARM when testing v145 libraries."
+}
+
 $platform = $platformByArchitecture[$Architecture]
 if ($Architecture -eq 'ARM') {
   # Windows SDK 10.0.26100.0 no longer supports 32-bit ARM. Pin the Visual
@@ -77,7 +90,7 @@ if ([string]::IsNullOrWhiteSpace($bundleRoot) -or -not (Test-Path (Join-Path $bu
 }
 
 foreach ($requiredPath in @(
-  "lib\native\$Architecture\$Configuration\Ldk.lib",
+  "lib\native\$Toolset\$Architecture\$Configuration\Ldk.lib",
   'share\ldk\cmake\ldk-config.cmake',
   'share\ldk\cmake\ldk-config-version.cmake',
   'share\ldk\cmake\Ldk.cmake',
@@ -108,6 +121,7 @@ endif()
 project(ldk_release_asset_smoke LANGUAGES C)
 
 find_package(ldk CONFIG REQUIRED PATHS "$cmakeBundleRoot" NO_DEFAULT_PATH)
+set(LDK_PREBUILT_TOOLSET "$Toolset")
 
 ldk_add_driver(ldk_release_asset_smoke main.c)
 "@
@@ -140,11 +154,11 @@ DriverEntry(
 '@
 Set-Content -LiteralPath (Join-Path $consumerDirectory 'main.c') -Value $mainC -Encoding UTF8
 
-$buildDirectory = Join-Path $WorkDirectory "build_$Architecture"
+$buildDirectory = Join-Path $WorkDirectory "build_${Toolset}_$Architecture"
 $configureArgs = @(
   '-S', $consumerDirectory,
   '-B', $buildDirectory,
-  '-G', 'Visual Studio 17 2022',
+  '-G', $generatorByToolset[$Toolset],
   '-A', $platform,
   '-T', 'host=x64',
   "-DLDK_WDK_VERSION=$WindowsSdkVersion",
@@ -153,13 +167,13 @@ $configureArgs = @(
   "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM=$WindowsSdkVersion"
 )
 
-Write-Host "Configuring prebuilt release asset consumer for $Architecture $Configuration"
+Write-Host "Configuring prebuilt release asset consumer for $Toolset $Architecture $Configuration"
 & cmake @configureArgs
 if ($LASTEXITCODE -ne 0) {
   throw "CMake configure failed with exit code $LASTEXITCODE."
 }
 
-Write-Host "Building prebuilt release asset consumer for $Architecture $Configuration"
+Write-Host "Building prebuilt release asset consumer for $Toolset $Architecture $Configuration"
 & cmake --build $buildDirectory --config $Configuration --target ldk_release_asset_smoke --parallel
 if ($LASTEXITCODE -ne 0) {
   throw "CMake build failed with exit code $LASTEXITCODE."


### PR DESCRIPTION
## Summary

- Publish prebuilt LDK libraries under `lib/native/<toolset>/<arch>/<config>`.
- Add v143 coverage for x86, x64, ARM, and ARM64, plus v145 coverage for x86, x64, and ARM64.
- Teach CMake and native MSBuild NuGet consumers to select the matching prebuilt toolset library.
- Add CI coverage for NuGet CMake consumers, native MSBuild consumers, release bundle consumers, and layout-only package checks.
- Keep release and NuGet packaging output clean by filtering stale assets.

## Why

VS2022 and VS2026 can consume different MSVC toolsets. The package layout now lets consumers pick the library that matches their compiler while intentionally omitting v145 ARM32, which is not available in the tested VS2026 Build Tools layout.

## Validation

- `git diff --check`
- PowerShell parser check for `scripts/nuget/*.ps1`
- XML parse check for `nuget/build/native/ldk.props`, `nuget/build/native/ldk.targets`, and `nuget/ldk.nuspec`
- `Pack-LdkNuGet.ps1 -Version 0.0.0-local -Toolset v143,v145 -Architecture x64`
- `Pack-LdkReleaseAssets.ps1 -Version 0.0.0-local -Toolset v143,v145 -Architecture x64`
- `Test-LdkNuGetMsBuildPackage.ps1` for v143 x64 Debug
- `Test-LdkNuGetMsBuildPackage.ps1` for v145 x64 Debug
- Earlier local smoke coverage also passed for v143/v145 x64 Release MSBuild consumers and v143/v145 x64 Debug CMake/release-bundle consumers.